### PR TITLE
Define DiskUsage-specific agent rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,480 +1,387 @@
 # Repository Agent Rules
 
-These rules apply to all automated coding agents and repository-wide maintenance work.
-
-## Mandatory repository-wide audit and deep-refactoring protocol
-
-When a task requests a full audit, cleanup, optimization, simplification, or deep refactoring, the rules in this section are mandatory.
-
-A repository-wide audit is an implementation task, not merely a request for recommendations.
-
-### Objective
-
-Audit the entire repository and reduce the codebase to the minimum necessary complexity while preserving 100% of its current functionality and externally observable behavior.
-
-The refactored project must preserve, unless an explicitly requested bug fix requires otherwise:
-
-- user-facing functionality;
-- application behavior;
-- UI/UX;
-- business or game logic;
-- public APIs and contracts;
-- persisted and exchanged data formats;
-- platform-specific behavior;
-- documented capabilities;
-- edge-case semantics.
-
-The goal is minimum **necessary complexity**, not minimum line count.
-
-Do not perform code golf.
-
-A change is justified only when it objectively reduces one or more of:
-
-- code volume;
-- duplication;
-- conceptual complexity;
-- branching or state;
-- coupling;
-- maintenance burden;
-- dependency surface;
-- runtime cost;
-- regression risk.
-
-If a change merely makes the implementation different without making it demonstrably smaller, simpler, safer, clearer, or more efficient, leave the code unchanged.
-
-Default decision rule:
-
-- if code is proven unnecessary, delete it;
-- if code can be objectively simplified, simplify it;
-- if duplicate responsibilities can be safely consolidated, consolidate them;
-- if an abstraction no longer provides value, remove it;
-- if the benefit is uncertain, preserve the existing working behavior.
-
-### Required audit scope
-
-Before making repository-wide refactoring changes, inspect the complete repository rather than only recently changed files or obvious hotspots.
-
-Review all relevant areas, including:
-
-- production source code;
-- tests and test utilities;
-- resources and assets;
-- configuration files;
-- build scripts and build configuration;
-- CI/CD workflows;
-- release tooling;
-- dependencies and development dependencies;
-- static-analysis and security configuration;
-- documentation;
-- platform-specific integration;
-- generated-code integration points;
-- directory and module structure.
-
-First establish:
-
-1. the actual architecture;
-2. authoritative sources of state and business logic;
-3. all current user-visible functionality;
-4. important internal behavior and contracts;
-5. persistence and compatibility requirements;
-6. framework-, build-, platform-, or convention-driven entry points.
-
-Only then begin removing or consolidating code.
-
-### Required removal candidates
-
-Actively search for and remove, when proven safe:
-
-- dead code;
-- unreachable code;
-- unused functions;
-- unused classes;
-- unused methods;
-- unused variables;
-- unused constants;
-- unused types;
-- unused interfaces;
-- unused imports and exports;
-- unused files;
-- unused resources and assets;
-- obsolete legacy code that no longer participates in current behavior;
-- temporary workarounds whose original constraint no longer exists;
-- duplicate or near-duplicate implementations;
-- unnecessary abstraction layers;
-- unnecessary wrappers;
-- unnecessary helper functions;
-- adapter chains that add no meaningful semantics;
-- redundant data conversions;
-- redundant intermediate objects;
-- redundant intermediate state;
-- redundant copies and transformations;
-- defensive checks for states already guaranteed by types, architecture, invariants, or earlier validation;
-- repeated validation of already validated data;
-- repeated checks of the same condition;
-- redundant fallbacks;
-- obsolete compatibility branches;
-- unused feature flags;
-- obsolete configuration options;
-- unused dependencies;
-- unused development dependencies;
-- duplicate-purpose dependencies;
-- commented-out historical code;
-- stale TODO/FIXME items;
-- leftovers from previous migrations or refactors.
-
-Pay particular attention to patterns such as:
-
-- repeated null/state/bounds checks;
-- nested checks of the same condition;
-- repeated validation across adjacent layers;
-- unnecessary `try/catch` blocks;
-- wrapper -> wrapper -> wrapper call chains;
-- DTO/model conversion chains;
-- multiple representations of the same authoritative state;
-- temporary states that duplicate existing state;
-- compatibility paths left behind after migrations;
-- helpers with only one trivial caller;
-- abstractions created for future scenarios that never materialized.
-
-### Proving code is unused
-
-Do not classify code as unused solely because a textual search finds no direct call.
-
-Before removing anything, check for indirect or convention-driven use through:
-
-- callbacks;
-- events;
-- observers;
-- dependency injection;
-- reflection;
-- dynamic loading;
-- serialization/deserialization;
-- framework conventions;
-- lifecycle hooks;
-- manifests;
-- resources;
-- routing;
-- configuration;
-- generated code;
-- build scripts;
-- CI/CD;
-- release tooling;
-- plugins;
-- native/platform integration;
-- test or debug tooling;
-- external/public contracts.
-
-When uncertainty remains, preserve the code until its lack of use can be demonstrated.
-
-### Required simplification review
-
-Look for opportunities to safely:
-
-- shorten code without reducing readability;
-- simplify control flow;
-- reduce nesting;
-- reduce mutable state;
-- reduce the number of branches;
-- merge equivalent paths;
-- merge components with the same responsibility;
-- remove unnecessary temporary values;
-- remove unnecessary objects and allocations;
-- remove redundant copies;
-- remove repeated transformations;
-- remove redundant loops or passes over the same data;
-- compute invariant values once instead of repeatedly;
-- replace custom code with standard language, platform, framework, or library facilities when clearly simpler;
-- eliminate repeated business logic;
-- centralize genuinely shared logic when doing so reduces total code and conceptual complexity;
-- reduce coupling;
-- remove premature generalization;
-- remove architecture that exists only for hypothetical future requirements.
-
-Do not introduce an abstraction merely to satisfy DRY.
-
-Similar-looking code should only be unified when the resulting abstraction reduces real duplication and overall complexity.
-
-### Architecture review
-
-Explicitly determine whether:
-
-- historical layers are still necessary;
-- historical components are still necessary;
-- abstractions are disproportionate to the actual problem;
-- interfaces exist with only one implementation and no meaningful boundary benefit;
-- classes or modules can be safely merged;
-- classes or modules can be safely deleted;
-- responsibilities are unnecessarily fragmented;
-- there is premature generalization;
-- there is speculative extensibility;
-- infrastructure exists only for hypothetical future features;
-- current architecture reflects requirements that no longer exist;
-- duplicated state or business logic creates unnecessary coupling;
-- implementation complexity is proportional to actual product complexity.
-
-Prefer the simplest architecture that fully supports the current product.
-
-Do not perform a large rewrite merely because another architecture appears cleaner, newer, or more fashionable.
-
-### Performance review
-
-Review performance only where there is practical value.
-
-Look for:
-
-- repeated calculations;
-- repeated queries;
-- repeated reads;
-- unnecessary parsing;
-- repeated transformations of unchanged data;
-- avoidable allocations;
-- unnecessary copies;
-- redundant loops;
-- multiple passes that can safely become one;
-- unnecessary render/re-render/rebuild/recompute work;
-- inappropriate data structures for actual access patterns;
-- invariant operations performed repeatedly instead of once;
-- unnecessary work in frequently executed paths.
-
-Do not introduce micro-optimizations that reduce readability or maintainability without an obvious or measurable benefit.
-
-### Dependency review
-
-Review every production and development dependency.
-
-For each dependency:
-
-- verify that it is actually used;
-- verify that its purpose is still required;
-- remove unused dependencies;
-- remove obsolete dependencies;
-- identify multiple libraries serving the same purpose;
-- consolidate overlapping dependencies where safe;
-- prefer standard language/platform/framework functionality when it clearly replaces a dependency with less total complexity.
-
-A dependency may be replaced by a small local implementation only when doing so clearly reduces overall complexity, risk, maintenance cost, or artifact size.
-
-Do not replace a mature, well-maintained library with custom code merely to reduce the dependency count.
-
-### Non-negotiable behavior-preservation rules
-
-Unless explicitly requested, a repository-wide cleanup or refactor must not intentionally:
-
-- remove user-facing functionality;
-- change existing UX;
-- change visual behavior;
-- change business logic;
-- change game rules;
-- change public APIs;
-- change public contracts;
-- change persisted data formats;
-- change exchanged data formats;
-- change edge-case behavior;
-- change platform behavior;
-- weaken compatibility;
-- weaken accessibility;
-- weaken security or privacy controls;
-- reduce functionality merely to reduce code size;
-- add unrelated functionality;
-- introduce new architectural layers only to satisfy generic best practices;
-- perform a broad rewrite without a demonstrated need.
-
-Repository-specific invariants defined elsewhere in this file remain mandatory throughout the refactor.
-
-### Required execution workflow
-
-For a repository-wide audit or deep refactor:
-
-1. Inspect the entire repository.
-
-2. Establish the current:
-   - architecture;
-   - feature set;
-   - user-visible behavior;
-   - internal contracts;
-   - authoritative state;
-   - persistence behavior;
-   - platform constraints.
-
-3. Collect reliable baseline statistics where practical.
-
-4. Build an internal candidate list grouped into:
-   - deletion;
-   - consolidation;
-   - simplification;
-   - architecture reduction;
-   - dependency cleanup;
-   - practical performance optimization.
-
-5. Validate every removal against both direct and indirect usage.
-
-6. Rank candidates by:
-   - confidence;
-   - regression risk;
-   - complexity reduction;
-   - maintenance benefit.
-
-7. Apply changes in small, logically coherent groups rather than as one uncontrolled rewrite.
-
-8. After every meaningful group, run the relevant available checks, such as:
-   - unit tests;
-   - integration tests;
-   - regression tests;
-   - lint;
-   - formatting checks;
-   - type checking;
-   - compilation;
-   - build;
-   - static analysis;
-   - dependency/security checks;
-   - project-specific validation.
-
-9. If critical behavior lacks sufficient test coverage for a contemplated risky change, first add the minimum regression test required to capture the existing behavior.
-
-10. Keep behavior-preserving refactoring separate from unrelated feature development.
-
-11. When a candidate cannot be proven safe, leave it unchanged and record the reason.
-
-12. Complete the first refactoring pass.
-
-13. Perform a mandatory second full pass over the already-refactored repository.
-
-14. During the second pass, look again for:
-   - newly exposed simplification opportunities;
-   - remaining dead code;
-   - residual duplication;
-   - unnecessary abstractions;
-   - unnecessary wrappers;
-   - redundant checks;
-   - unused dependencies;
-   - residual legacy;
-   - temporary structures made obsolete by the first pass.
-
-15. Finish with the complete available project verification suite.
-
-### Validation requirements
-
-The final verification should include every applicable repository check.
-
-Examples include:
-
-- clean build;
-- complete unit-test suite;
-- integration tests;
+These rules apply to all automated coding agents and repository maintenance work in DiskUsage.
+
+## Project identity and priorities
+
+DiskUsage is a native, privacy-first disk space analyzer for macOS built with SwiftUI and AppKit.
+
+Preserve these priorities, in order:
+
+1. File-system and scan correctness.
+2. Safety of user file operations.
+3. UI responsiveness and cancellation.
+4. User privacy and macOS security boundaries.
+5. Clear and predictable UX.
+6. Minimal implementation complexity.
+
+DiskUsage is a local utility. It must remain useful without an account, network connection, cloud service, or backend.
+
+Do not add unrelated system-cleaner, optimizer, antivirus, cloud-storage, telemetry, or account functionality without an explicit product decision.
+
+## Product boundaries
+
+The core product responsibilities are:
+
+- scan the user's home directory, root filesystem, or a user-selected folder;
+- represent scanned disk usage as a hierarchical model;
+- present the result through tree and sunburst views;
+- report inaccessible locations honestly;
+- reveal an item in Finder;
+- copy an item's path;
+- move an explicitly selected item to the macOS Trash;
+- preserve local application settings.
+
+Do not silently expand these responsibilities.
+
+In particular, do not add automatic cleanup, background deletion, duplicate-file deletion, permanent deletion, privileged helpers, network scanning, or remote file operations without an explicit product decision.
+
+## Privacy
+
+DiskUsage is local-first and privacy-first.
+
+Do not add:
+
+- analytics;
+- advertising;
+- tracking;
+- telemetry;
+- user accounts;
+- remote logging;
+- cloud synchronization;
+- upload of file names, paths, directory structure, scan results, or file contents;
+- background network communication.
+
+File-system paths and scan results are potentially sensitive user data.
+
+Do not log full user paths or directory contents unless required for explicit local debugging and never persist such debugging data in production.
+
+Do not commit personal scan output or real user file-system paths as fixtures or examples.
+
+## File-system authority and scan model
+
+`DiskScanner` is the authoritative filesystem traversal layer.
+
+`FolderUsage` is a derived snapshot of a completed scan. It is not an independent source of filesystem truth.
+
+SwiftUI views must render scan state and request actions; they must not independently enumerate, mutate, or reinterpret the filesystem.
+
+Keep scan semantics explicit.
+
+A scan must distinguish between:
+
+- successfully observed filesystem data;
+- inaccessible or restricted locations;
+- cancelled or incomplete work.
+
+Never present inaccessible data as successfully measured.
+
+Do not invent sizes for unreadable files or directories.
+
+The scan tree represents a snapshot. The filesystem may change after scanning, so code must not assume that a scanned path still exists or still has the same size when a later user action occurs.
+
+## Size semantics
+
+DiskUsage currently measures file usage from filesystem-reported allocated-size resource values.
+
+Do not silently change from allocated size to logical file size, apparent size, compressed size, or another size definition.
+
+Any intentional change to size semantics must update:
+
+- the scanner;
+- user-visible wording where necessary;
 - regression tests;
-- lint;
-- formatting verification;
-- type checking;
-- static analysis;
-- dependency audit;
-- security checks;
-- platform-specific builds;
-- production build;
-- project-specific verification scripts.
+- relevant documentation.
 
-Do not claim a check passed unless it was actually executed successfully.
+Do not assume that the sum of scanned files must equal the volume-level "used space" value.
 
-If a check cannot be run because of environment, credentials, hardware, platform, unavailable tooling, or another external limitation, state that explicitly.
+Volume capacity and scanner totals may legitimately differ because of filesystem metadata, snapshots, clones, purgeable space, inaccessible data, allocation behavior, and other filesystem-level effects.
 
-### Comments during refactoring
+Do not claim exact physical disk consumption beyond what the available macOS filesystem APIs can support.
 
-Preserve the repository's comment policy.
+## Path and identity rules
 
-As a default:
+Use standardized filesystem URLs or paths consistently.
 
-- keep comments to the minimum necessary;
-- keep source-code comments in English;
-- remove stale comments;
-- remove misleading comments;
-- remove redundant comments;
-- do not add comments that merely narrate obvious code;
-- retain comments that explain a non-obvious reason, constraint, workaround, invariant, compatibility requirement, or important contract.
+`FolderUsage.id` is path-based. Do not casually change path identity semantics because SwiftUI identity, tree mutation, navigation, and deletion logic depend on them.
 
-Do not replace clear code with explanatory comments when the code itself can be made self-explanatory.
+Do not compare unrelated filesystem objects only by display name.
 
-### Completion standard
+Do not resolve or follow symbolic links, aliases, packages, mount points, or other filesystem indirections differently without explicitly reviewing the correctness, cycle, duplication, security, and UX consequences.
 
-A repository-wide audit/refactoring task is not complete merely because:
+Changes to hidden-file, package, symlink, mount-point, or filesystem-boundary behavior require focused regression coverage.
 
-- code was formatted;
-- static analysis was run;
-- recommendations were listed;
-- potential improvements were described;
-- only recently modified files were reviewed.
+## Scan concurrency
 
-Safe and justified improvements must be implemented directly.
+Filesystem traversal is potentially slow and must not block the main actor or SwiftUI rendering.
 
-The final codebase should be objectively smaller, simpler, less duplicated, less coupled, easier to reason about, or easier to maintain while preserving behavior.
+Keep expensive directory enumeration, resource-value lookup, tree construction, and equivalent scanning work off the UI execution path.
 
-### Required final report
+Main-actor work should be limited to publishing UI state and performing AppKit/SwiftUI operations that require it.
 
-At completion, report:
+There must be at most one authoritative active scan for a `DiskScannerViewModel`.
 
-1. **Removed**
-   - dead code;
-   - unused files/resources;
-   - obsolete compatibility code;
-   - unnecessary abstractions;
-   - other removed components.
+Starting, cancelling, replacing, or completing a scan must not allow stale asynchronous work to overwrite newer UI state.
 
-2. **Consolidated**
-   - duplicated logic;
-   - equivalent components;
-   - repeated validation;
-   - shared responsibilities.
+Cancellation is part of correctness.
 
-3. **Simplified**
-   - control flow;
-   - state;
-   - architecture;
-   - transformations;
-   - hot paths.
+Long-running traversal must check cancellation regularly and yield often enough to keep cancellation responsive.
 
-4. **Dependencies**
-   - dependencies removed;
-   - duplicate-purpose dependencies consolidated;
-   - dependency changes intentionally not made and why.
+A cancelled scan must not later publish itself as a successful completed scan.
 
-5. **Legacy**
-   - legacy components found;
-   - which were removed;
-   - which remain and why.
+Progress reporting must be throttled or sampled. Do not publish SwiftUI state for every discovered filesystem entry.
 
-6. **Intentionally unchanged**
-   - candidates reviewed but preserved;
-   - reason removal or simplification could not be proven safe.
+Do not use `@unchecked Sendable` as a substitute for reasoning about ownership and synchronization.
 
-7. **Verification**
-   - tests run;
-   - builds run;
-   - lint/typecheck/static-analysis/security checks run;
-   - their results.
+Any shared mutable scanning state must have an explicit synchronization strategy.
 
-8. **Limitations**
-   - areas that could not be safely optimized;
-   - missing coverage;
-   - unavailable environment/tooling;
-   - external constraints.
+## Resource usage
 
-9. **Before/after statistics**, when they can be measured reliably:
-   - file count;
-   - source line count;
-   - dependency count;
-   - test count;
-   - production/build artifact size;
-   - other project-relevant metrics.
+Assume users may scan millions of filesystem entries.
 
-Never invent statistics.
+Avoid unnecessary whole-tree copies, repeated recursive transformations, duplicate indexes, unbounded caches, and per-entry retained temporary objects.
 
-Use the same counting method for before and after values.
+Do not optimize by sacrificing correctness, cancellation, or filesystem safety.
 
-### Final principle
+Performance changes must be justified by an observable or measurable cost.
 
-When choosing between:
+Prefer bounded or incremental work where practical.
 
-- preserving working code whose necessity is uncertain;
-- deleting code because it appears unnecessary;
+Do not run expensive recursive sorting, layout preparation, or data transformation repeatedly on the main actor when the same result can be safely computed once or off the UI path.
 
-preserve the working behavior until the code is proven unnecessary.
+## File operations
 
-The final goal is a codebase containing only the complexity required to implement the project's current functionality: as small, clean, understandable, maintainable, and efficient as reasonably possible, without functional regressions.
+User file operations are security-sensitive.
+
+The destructive operation currently supported by the product is moving an explicitly selected item to the macOS Trash.
+
+Do not replace Trash behavior with permanent deletion such as:
+
+- `FileManager.removeItem`;
+- `unlink`;
+- `rm`;
+- shell scripts;
+- recursive permanent deletion;
+- privileged deletion.
+
+Permanent deletion requires an explicit product decision and separate safety review.
+
+A file operation must target exactly the item explicitly selected by the user.
+
+Do not derive a destructive target from display text, partial path matching, stale selection state, or a parent directory unless that parent is the explicitly selected item.
+
+Update the in-memory tree only after the operating-system file operation succeeds.
+
+On failure:
+
+- preserve the scanned model;
+- surface the error clearly;
+- do not pretend space was freed.
+
+Deletion confirmation behavior is controlled by the user setting and must remain consistent across tree and sunburst views.
+
+Tests for destructive operations must use disposable temporary directories and files. Never run destructive tests against real user data.
+
+## macOS security boundaries
+
+Respect macOS TCC, Full Disk Access, SIP, sandbox, and filesystem permission boundaries.
+
+Never attempt to bypass system privacy controls.
+
+When access is denied, report the location as restricted or otherwise incomplete rather than fabricating a result.
+
+Full Disk Access must remain a user-controlled macOS permission.
+
+Do not introduce privileged helpers, authorization services, private entitlements, or security-boundary bypasses merely to make scanning appear more complete.
+
+Changes to:
+
+- `DiskUsage.entitlements`;
+- App Sandbox configuration;
+- Hardened Runtime;
+- code signing;
+- Full Disk Access behavior;
+- filesystem capabilities
+
+are security and release changes, not routine refactoring.
+
+Review them explicitly.
+
+## Settings and persistence
+
+`AppSettings` owns persisted application preferences.
+
+Preserve existing `UserDefaults` keys and enum raw values unless an intentional migration is provided.
+
+Do not reset existing settings during ordinary refactoring.
+
+A setting exposed in the UI must affect actual application behavior.
+
+Do not retain non-functional or misleading settings.
+
+Changes to language handling must preserve predictable startup and restart behavior.
+
+## UI architecture
+
+SwiftUI views are presentation code.
+
+Keep filesystem traversal and destructive filesystem mutation out of view implementations.
+
+Prefer one authoritative action path for each operation so that tree and sunburst views behave identically.
+
+Shared actions such as reveal, copy path, and move to Trash should not diverge between representations.
+
+Tree and sunburst views must render the same authoritative `FolderUsage` data.
+
+Changing representation must not change scan semantics or filesystem behavior.
+
+Do not let visualization-specific state become authoritative application state.
+
+## Sunburst and tree correctness
+
+Sorting and visualization may reorder or filter presentation, but they must not modify the authoritative scan model.
+
+Displayed sizes and percentages must derive from the same underlying `FolderUsage` values.
+
+Sunburst geometry must remain derived presentation state.
+
+Navigation into a sunburst node must not mutate the scan tree.
+
+Deleting an item must update all representations consistently.
+
+Do not hide significant scan errors merely because one visualization has no natural place to display them.
+
+## Localization
+
+User-visible application text must use the string catalog unless a value is intentionally language-independent.
+
+Maintain English and Russian localization together.
+
+Do not introduce a new visible English-only or Russian-only string into an otherwise localized UI.
+
+Keep localization keys stable when possible.
+
+Changing localization infrastructure must not erase or silently invalidate existing translations.
+
+## Dependencies
+
+DiskUsage currently relies on Apple system frameworks and does not require third-party runtime dependencies.
+
+Keep it dependency-light.
+
+Add a third-party package only for a concrete current requirement that cannot be implemented more simply and safely with Foundation, SwiftUI, AppKit, or other appropriate Apple frameworks.
+
+Do not add dependencies merely for trivial helpers, formatting, collections, or architectural patterns.
+
+Any dependency addition must consider:
+
+- binary size;
+- maintenance;
+- security;
+- privacy;
+- licensing;
+- minimum macOS version;
+- Swift/Xcode compatibility.
+
+## Project and release configuration
+
+Treat the application bundle identifier as a release identity.
+
+Do not change `PRODUCT_BUNDLE_IDENTIFIER`, signing identity, entitlements, versioning, minimum macOS support, or distribution configuration as incidental cleanup.
+
+The Xcode project, English README, and Russian README must agree on supported macOS and Xcode requirements.
+
+Do not silently raise the deployment target.
+
+Do not commit local Xcode user state such as `xcuserdata`.
+
+Do not add unrelated files to the application Resources build phase.
+
+Keep generated build products, derived data, local signing artifacts, credentials, and developer-specific configuration out of the repository.
+
+Preserve the repository license unless an explicit licensing change is requested.
+
+## Verification
+
+For changes that affect buildable source or Xcode configuration, run an applicable macOS build before completion.
+
+A baseline non-signing verification command is:
+
+```text
+xcodebuild \
+  -project DiskUsage.xcodeproj \
+  -scheme DiskUsage \
+  -configuration Debug \
+  -destination 'platform=macOS' \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+```
+
+Release-sensitive changes should also verify the Release configuration where the available environment supports it.
+
+Never claim a build or test passed unless it actually ran successfully.
+
+If verification cannot run because the available environment is not macOS, does not have a compatible Xcode version, or lacks another required capability, state that explicitly.
+
+## Regression coverage
+
+When practical, pure filesystem and model behavior should be covered independently of SwiftUI.
+
+High-value regression areas include:
+
+- hierarchical size accumulation;
+- `FolderUsage.removing`;
+- deterministic sorting;
+- cancellation;
+- stale-scan suppression;
+- hidden-file behavior;
+- package behavior;
+- symbolic-link behavior;
+- inaccessible paths;
+- empty directories and zero-size files;
+- very deep trees;
+- Unicode file names;
+- safe Trash behavior using temporary fixtures.
+
+A bug fix in scanner, model, file-operation, or settings behavior should add the smallest practical regression test that proves the corrected behavior.
+
+Do not use a user's real home directory or root filesystem as an automated test fixture.
+
+## Change discipline
+
+Prefer the smallest correct change.
+
+Do not introduce additional architecture layers merely because they are common in larger Swift applications.
+
+Keep filesystem logic, application state, and presentation separated where that separation has concrete value.
+
+Avoid speculative protocols, repositories, service locators, coordinators, dependency containers, and other abstractions without a current requirement.
+
+Remove duplication when there is one genuine shared responsibility, but do not create an abstraction merely to satisfy DRY.
+
+Do not mix unrelated feature work with cleanup or behavior-preserving refactoring.
+
+## Comments and documentation
+
+Keep source-code comments minimal, necessary, current, and English-only.
+
+Remove stale, redundant, narrative, and commented-out historical code.
+
+Comments should explain only non-obvious:
+
+- filesystem behavior;
+- concurrency constraints;
+- safety requirements;
+- platform limitations;
+- compatibility reasons;
+- invariants.
+
+Prefer clear Swift code over explanatory comments.
+
+When behavior, permissions, minimum system requirements, settings, or user-visible capabilities change, update both `README.md` and `README.ru.md` where applicable.
+
+## Repository-wide audit and deep refactoring
+
+For a full repository audit, cleanup, optimization, simplification, or deep-refactoring task, read and follow `docs/agent/AUDIT_REFACTOR.md` in full before editing.
+
+The DiskUsage-specific correctness, privacy, filesystem-safety, and macOS-security rules in this file remain mandatory throughout that process and take precedence over generic simplification goals.

--- a/docs/agent/AUDIT_REFACTOR.md
+++ b/docs/agent/AUDIT_REFACTOR.md
@@ -1,0 +1,480 @@
+# Repository Agent Rules
+
+These rules apply to all automated coding agents and repository-wide maintenance work.
+
+## Mandatory repository-wide audit and deep-refactoring protocol
+
+When a task requests a full audit, cleanup, optimization, simplification, or deep refactoring, the rules in this section are mandatory.
+
+A repository-wide audit is an implementation task, not merely a request for recommendations.
+
+### Objective
+
+Audit the entire repository and reduce the codebase to the minimum necessary complexity while preserving 100% of its current functionality and externally observable behavior.
+
+The refactored project must preserve, unless an explicitly requested bug fix requires otherwise:
+
+- user-facing functionality;
+- application behavior;
+- UI/UX;
+- business or game logic;
+- public APIs and contracts;
+- persisted and exchanged data formats;
+- platform-specific behavior;
+- documented capabilities;
+- edge-case semantics.
+
+The goal is minimum **necessary complexity**, not minimum line count.
+
+Do not perform code golf.
+
+A change is justified only when it objectively reduces one or more of:
+
+- code volume;
+- duplication;
+- conceptual complexity;
+- branching or state;
+- coupling;
+- maintenance burden;
+- dependency surface;
+- runtime cost;
+- regression risk.
+
+If a change merely makes the implementation different without making it demonstrably smaller, simpler, safer, clearer, or more efficient, leave the code unchanged.
+
+Default decision rule:
+
+- if code is proven unnecessary, delete it;
+- if code can be objectively simplified, simplify it;
+- if duplicate responsibilities can be safely consolidated, consolidate them;
+- if an abstraction no longer provides value, remove it;
+- if the benefit is uncertain, preserve the existing working behavior.
+
+### Required audit scope
+
+Before making repository-wide refactoring changes, inspect the complete repository rather than only recently changed files or obvious hotspots.
+
+Review all relevant areas, including:
+
+- production source code;
+- tests and test utilities;
+- resources and assets;
+- configuration files;
+- build scripts and build configuration;
+- CI/CD workflows;
+- release tooling;
+- dependencies and development dependencies;
+- static-analysis and security configuration;
+- documentation;
+- platform-specific integration;
+- generated-code integration points;
+- directory and module structure.
+
+First establish:
+
+1. the actual architecture;
+2. authoritative sources of state and business logic;
+3. all current user-visible functionality;
+4. important internal behavior and contracts;
+5. persistence and compatibility requirements;
+6. framework-, build-, platform-, or convention-driven entry points.
+
+Only then begin removing or consolidating code.
+
+### Required removal candidates
+
+Actively search for and remove, when proven safe:
+
+- dead code;
+- unreachable code;
+- unused functions;
+- unused classes;
+- unused methods;
+- unused variables;
+- unused constants;
+- unused types;
+- unused interfaces;
+- unused imports and exports;
+- unused files;
+- unused resources and assets;
+- obsolete legacy code that no longer participates in current behavior;
+- temporary workarounds whose original constraint no longer exists;
+- duplicate or near-duplicate implementations;
+- unnecessary abstraction layers;
+- unnecessary wrappers;
+- unnecessary helper functions;
+- adapter chains that add no meaningful semantics;
+- redundant data conversions;
+- redundant intermediate objects;
+- redundant intermediate state;
+- redundant copies and transformations;
+- defensive checks for states already guaranteed by types, architecture, invariants, or earlier validation;
+- repeated validation of already validated data;
+- repeated checks of the same condition;
+- redundant fallbacks;
+- obsolete compatibility branches;
+- unused feature flags;
+- obsolete configuration options;
+- unused dependencies;
+- unused development dependencies;
+- duplicate-purpose dependencies;
+- commented-out historical code;
+- stale TODO/FIXME items;
+- leftovers from previous migrations or refactors.
+
+Pay particular attention to patterns such as:
+
+- repeated null/state/bounds checks;
+- nested checks of the same condition;
+- repeated validation across adjacent layers;
+- unnecessary `try/catch` blocks;
+- wrapper -> wrapper -> wrapper call chains;
+- DTO/model conversion chains;
+- multiple representations of the same authoritative state;
+- temporary states that duplicate existing state;
+- compatibility paths left behind after migrations;
+- helpers with only one trivial caller;
+- abstractions created for future scenarios that never materialized.
+
+### Proving code is unused
+
+Do not classify code as unused solely because a textual search finds no direct call.
+
+Before removing anything, check for indirect or convention-driven use through:
+
+- callbacks;
+- events;
+- observers;
+- dependency injection;
+- reflection;
+- dynamic loading;
+- serialization/deserialization;
+- framework conventions;
+- lifecycle hooks;
+- manifests;
+- resources;
+- routing;
+- configuration;
+- generated code;
+- build scripts;
+- CI/CD;
+- release tooling;
+- plugins;
+- native/platform integration;
+- test or debug tooling;
+- external/public contracts.
+
+When uncertainty remains, preserve the code until its lack of use can be demonstrated.
+
+### Required simplification review
+
+Look for opportunities to safely:
+
+- shorten code without reducing readability;
+- simplify control flow;
+- reduce nesting;
+- reduce mutable state;
+- reduce the number of branches;
+- merge equivalent paths;
+- merge components with the same responsibility;
+- remove unnecessary temporary values;
+- remove unnecessary objects and allocations;
+- remove redundant copies;
+- remove repeated transformations;
+- remove redundant loops or passes over the same data;
+- compute invariant values once instead of repeatedly;
+- replace custom code with standard language, platform, framework, or library facilities when clearly simpler;
+- eliminate repeated business logic;
+- centralize genuinely shared logic when doing so reduces total code and conceptual complexity;
+- reduce coupling;
+- remove premature generalization;
+- remove architecture that exists only for hypothetical future requirements.
+
+Do not introduce an abstraction merely to satisfy DRY.
+
+Similar-looking code should only be unified when the resulting abstraction reduces real duplication and overall complexity.
+
+### Architecture review
+
+Explicitly determine whether:
+
+- historical layers are still necessary;
+- historical components are still necessary;
+- abstractions are disproportionate to the actual problem;
+- interfaces exist with only one implementation and no meaningful boundary benefit;
+- classes or modules can be safely merged;
+- classes or modules can be safely deleted;
+- responsibilities are unnecessarily fragmented;
+- there is premature generalization;
+- there is speculative extensibility;
+- infrastructure exists only for hypothetical future features;
+- current architecture reflects requirements that no longer exist;
+- duplicated state or business logic creates unnecessary coupling;
+- implementation complexity is proportional to actual product complexity.
+
+Prefer the simplest architecture that fully supports the current product.
+
+Do not perform a large rewrite merely because another architecture appears cleaner, newer, or more fashionable.
+
+### Performance review
+
+Review performance only where there is practical value.
+
+Look for:
+
+- repeated calculations;
+- repeated queries;
+- repeated reads;
+- unnecessary parsing;
+- repeated transformations of unchanged data;
+- avoidable allocations;
+- unnecessary copies;
+- redundant loops;
+- multiple passes that can safely become one;
+- unnecessary render/re-render/rebuild/recompute work;
+- inappropriate data structures for actual access patterns;
+- invariant operations performed repeatedly instead of once;
+- unnecessary work in frequently executed paths.
+
+Do not introduce micro-optimizations that reduce readability or maintainability without an obvious or measurable benefit.
+
+### Dependency review
+
+Review every production and development dependency.
+
+For each dependency:
+
+- verify that it is actually used;
+- verify that its purpose is still required;
+- remove unused dependencies;
+- remove obsolete dependencies;
+- identify multiple libraries serving the same purpose;
+- consolidate overlapping dependencies where safe;
+- prefer standard language/platform/framework functionality when it clearly replaces a dependency with less total complexity.
+
+A dependency may be replaced by a small local implementation only when doing so clearly reduces overall complexity, risk, maintenance cost, or artifact size.
+
+Do not replace a mature, well-maintained library with custom code merely to reduce the dependency count.
+
+### Non-negotiable behavior-preservation rules
+
+Unless explicitly requested, a repository-wide cleanup or refactor must not intentionally:
+
+- remove user-facing functionality;
+- change existing UX;
+- change visual behavior;
+- change business logic;
+- change game rules;
+- change public APIs;
+- change public contracts;
+- change persisted data formats;
+- change exchanged data formats;
+- change edge-case behavior;
+- change platform behavior;
+- weaken compatibility;
+- weaken accessibility;
+- weaken security or privacy controls;
+- reduce functionality merely to reduce code size;
+- add unrelated functionality;
+- introduce new architectural layers only to satisfy generic best practices;
+- perform a broad rewrite without a demonstrated need.
+
+Repository-specific invariants defined elsewhere in this file remain mandatory throughout the refactor.
+
+### Required execution workflow
+
+For a repository-wide audit or deep refactor:
+
+1. Inspect the entire repository.
+
+2. Establish the current:
+   - architecture;
+   - feature set;
+   - user-visible behavior;
+   - internal contracts;
+   - authoritative state;
+   - persistence behavior;
+   - platform constraints.
+
+3. Collect reliable baseline statistics where practical.
+
+4. Build an internal candidate list grouped into:
+   - deletion;
+   - consolidation;
+   - simplification;
+   - architecture reduction;
+   - dependency cleanup;
+   - practical performance optimization.
+
+5. Validate every removal against both direct and indirect usage.
+
+6. Rank candidates by:
+   - confidence;
+   - regression risk;
+   - complexity reduction;
+   - maintenance benefit.
+
+7. Apply changes in small, logically coherent groups rather than as one uncontrolled rewrite.
+
+8. After every meaningful group, run the relevant available checks, such as:
+   - unit tests;
+   - integration tests;
+   - regression tests;
+   - lint;
+   - formatting checks;
+   - type checking;
+   - compilation;
+   - build;
+   - static analysis;
+   - dependency/security checks;
+   - project-specific validation.
+
+9. If critical behavior lacks sufficient test coverage for a contemplated risky change, first add the minimum regression test required to capture the existing behavior.
+
+10. Keep behavior-preserving refactoring separate from unrelated feature development.
+
+11. When a candidate cannot be proven safe, leave it unchanged and record the reason.
+
+12. Complete the first refactoring pass.
+
+13. Perform a mandatory second full pass over the already-refactored repository.
+
+14. During the second pass, look again for:
+   - newly exposed simplification opportunities;
+   - remaining dead code;
+   - residual duplication;
+   - unnecessary abstractions;
+   - unnecessary wrappers;
+   - redundant checks;
+   - unused dependencies;
+   - residual legacy;
+   - temporary structures made obsolete by the first pass.
+
+15. Finish with the complete available project verification suite.
+
+### Validation requirements
+
+The final verification should include every applicable repository check.
+
+Examples include:
+
+- clean build;
+- complete unit-test suite;
+- integration tests;
+- regression tests;
+- lint;
+- formatting verification;
+- type checking;
+- static analysis;
+- dependency audit;
+- security checks;
+- platform-specific builds;
+- production build;
+- project-specific verification scripts.
+
+Do not claim a check passed unless it was actually executed successfully.
+
+If a check cannot be run because of environment, credentials, hardware, platform, unavailable tooling, or another external limitation, state that explicitly.
+
+### Comments during refactoring
+
+Preserve the repository's comment policy.
+
+As a default:
+
+- keep comments to the minimum necessary;
+- keep source-code comments in English;
+- remove stale comments;
+- remove misleading comments;
+- remove redundant comments;
+- do not add comments that merely narrate obvious code;
+- retain comments that explain a non-obvious reason, constraint, workaround, invariant, compatibility requirement, or important contract.
+
+Do not replace clear code with explanatory comments when the code itself can be made self-explanatory.
+
+### Completion standard
+
+A repository-wide audit/refactoring task is not complete merely because:
+
+- code was formatted;
+- static analysis was run;
+- recommendations were listed;
+- potential improvements were described;
+- only recently modified files were reviewed.
+
+Safe and justified improvements must be implemented directly.
+
+The final codebase should be objectively smaller, simpler, less duplicated, less coupled, easier to reason about, or easier to maintain while preserving behavior.
+
+### Required final report
+
+At completion, report:
+
+1. **Removed**
+   - dead code;
+   - unused files/resources;
+   - obsolete compatibility code;
+   - unnecessary abstractions;
+   - other removed components.
+
+2. **Consolidated**
+   - duplicated logic;
+   - equivalent components;
+   - repeated validation;
+   - shared responsibilities.
+
+3. **Simplified**
+   - control flow;
+   - state;
+   - architecture;
+   - transformations;
+   - hot paths.
+
+4. **Dependencies**
+   - dependencies removed;
+   - duplicate-purpose dependencies consolidated;
+   - dependency changes intentionally not made and why.
+
+5. **Legacy**
+   - legacy components found;
+   - which were removed;
+   - which remain and why.
+
+6. **Intentionally unchanged**
+   - candidates reviewed but preserved;
+   - reason removal or simplification could not be proven safe.
+
+7. **Verification**
+   - tests run;
+   - builds run;
+   - lint/typecheck/static-analysis/security checks run;
+   - their results.
+
+8. **Limitations**
+   - areas that could not be safely optimized;
+   - missing coverage;
+   - unavailable environment/tooling;
+   - external constraints.
+
+9. **Before/after statistics**, when they can be measured reliably:
+   - file count;
+   - source line count;
+   - dependency count;
+   - test count;
+   - production/build artifact size;
+   - other project-relevant metrics.
+
+Never invent statistics.
+
+Use the same counting method for before and after values.
+
+### Final principle
+
+When choosing between:
+
+- preserving working code whose necessity is uncertain;
+- deleting code because it appears unnecessary;
+
+preserve the working behavior until the code is proven unnecessary.
+
+The final goal is a codebase containing only the complexity required to implement the project's current functionality: as small, clean, understandable, maintainable, and efficient as reasonably possible, without functional regressions.


### PR DESCRIPTION
## Summary
- replace the generic-only root `AGENTS.md` with DiskUsage-specific engineering and product invariants
- document filesystem correctness, destructive-operation safety, concurrency/cancellation, privacy, macOS security boundaries, localization, project/release discipline, and verification expectations
- move the existing full repository-wide audit/deep-refactoring protocol to `docs/agent/AUDIT_REFACTOR.md` without removing it

## Scope
Documentation/instruction changes only. Application source, Xcode configuration, entitlements, and runtime behavior are unchanged.