### PR TITLE
Security hardening for Swift/macOS repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:30"
+      timezone: "Europe/Amsterdam"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,29 @@ name: CI
 
 on:
   push:
-    branches:
-      - main
-      - "audit/**"
+    branches: [main]
   pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   macos:
     runs-on: macos-26
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
     steps:
-      - uses: actions/checkout@v7
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Select Xcode 26.1.1
         run: sudo xcode-select -s /Applications/Xcode_26.1.1.app/Contents/Developer

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,77 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: '17 3 * * 1'
+
+permissions: {}
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  swift:
+    name: CodeQL Swift
+    runs-on: macos-26
+    timeout-minutes: 40
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Select Xcode 26.1.1
+        run: sudo xcode-select -s /Applications/Xcode_26.1.1.app/Contents/Developer
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: swift
+          build-mode: manual
+          queries: security-extended
+
+      - name: Build for analysis
+        run: >-
+          xcodebuild
+          -project DiskUsage.xcodeproj
+          -scheme DiskUsage
+          -configuration Debug
+          -destination 'platform=macOS'
+          CODE_SIGNING_ALLOWED=NO
+          clean build
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+
+  actions:
+    name: CodeQL Actions
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
+        with:
+          languages: actions
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,31 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: dependency-review-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          vulnerability-check: true
+          license-check: false
+          comment-summary-in-pr: never
+          retry-on-snapshot-warnings: true
+          retry-on-snapshot-warnings-timeout: 120
+          show-patched-versions: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,89 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: '41 4 * * 1'
+
+permissions: {}
+
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actions-policy:
+    name: Actions Policy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Verify workflow supply-chain policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+          import re
+          import sys
+
+          sha = re.compile(r"^[0-9a-fA-F]{40}$")
+          uses_line = re.compile(r"^\s*-?\s*uses:\s*([^\s#]+)")
+          failures = []
+
+          for path in sorted(Path('.github/workflows').glob('*.y*ml')):
+              text = path.read_text(encoding='utf-8')
+              if not re.search(r"(?m)^permissions:\s*\{\}\s*$", text):
+                  failures.append(f"{path}: missing top-level permissions: {{}}")
+              if re.search(r"(?m)^\s*pull_request_target\s*:", text):
+                  failures.append(f"{path}: pull_request_target is forbidden")
+
+              for number, line in enumerate(text.splitlines(), 1):
+                  match = uses_line.match(line)
+                  if not match:
+                      continue
+                  value = match.group(1).strip('"\'')
+                  if value.startswith('./') or value.startswith('docker://'):
+                      continue
+                  if '@' not in value:
+                      failures.append(f"{path}:{number}: action reference has no immutable revision: {value}")
+                      continue
+                  revision = value.rsplit('@', 1)[1]
+                  if not sha.fullmatch(revision):
+                      failures.append(f"{path}:{number}: action is not pinned to a full commit SHA: {value}")
+
+          if failures:
+              print('\n'.join(failures), file=sys.stderr)
+              sys.exit(1)
+          PY
+
+  gitleaks:
+    name: Gitleaks
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout full history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Scan repository for secrets
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITLEAKS_ENABLE_COMMENTS: 'false'

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,13 @@ xcuserdata/
 *.hmap
 *.dSYM
 *.dSYM.zip
+
+.env
+.env.*
+*.key
+*.pem
+*.p12
+*.pfx
+*.cer
+*.mobileprovision
+*.provisionprofile

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,6 +283,36 @@ Any dependency addition must consider:
 - minimum macOS version;
 - Swift/Xcode compatibility.
 
+## Repository and CI security
+
+Repository and CI hardening are part of the product security boundary.
+
+- Keep the default branch protected and require the established build, test, CodeQL, secret-scanning, dependency-review, and CI supply-chain gates before merge.
+- Keep external GitHub Actions pinned to full immutable commit SHAs. Do not use mutable tags or branch refs such as `@main`, `@latest`, or `@vN`.
+- Keep workflow-wide permissions empty or read-only and grant write permissions only to the specific job that requires them.
+- Do not use `pull_request_target` to execute untrusted repository code.
+- Never commit secrets, signing certificates, private keys, API tokens, credentials, `.env` files, or production configuration containing credentials.
+- Keep dependency update and vulnerability review automation enabled for every dependency ecosystem actually used by the repository.
+- Preserve reproducible or locked dependency resolution when a package ecosystem requiring a lockfile is introduced.
+- Re-run the applicable security gates after dependency, CI, release, signing, entitlement, or repository-wide refactoring changes.
+
+Do not weaken or bypass a required security gate merely to make a pull request mergeable. Fix the underlying issue or explicitly review and document why the control is no longer appropriate.
+
+## Release integrity
+
+DiskUsage is currently source-only. Do not add signing, release secrets, provenance, attestation, or release-tag automation until binary distribution is intentionally introduced.
+
+When signed or notarized binary releases are introduced:
+
+- keep signing material outside the repository and logs;
+- bind each release artifact to an immutable version tag and exact source commit;
+- protect release tags against modification and deletion;
+- use least-privilege release permissions and isolate signing credentials from ordinary pull-request workflows;
+- add artifact provenance/attestation when technically supported;
+- verify signatures, notarization, and packaged artifacts before publication.
+
+A release-security change requires a dedicated review of the complete release path.
+
 ## Project and release configuration
 
 Treat the application bundle identifier as a release identity.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Security Policy
+
+## Supported versions
+
+DiskUsage currently uses a source-only development model and has no published binary releases.
+
+| Version | Supported |
+| --- | --- |
+| Current `main` | Yes |
+| Older commits or forks | No |
+
+Security fixes are applied to the current development branch. A versioned support policy will be defined when signed/notarized binary releases begin.
+
+## Reporting a vulnerability
+
+Use GitHub private vulnerability reporting for this repository when available. Do not disclose a suspected vulnerability, credential, signing material, token, private key, or other sensitive detail in a public issue, discussion, pull request, commit message, or workflow log.
+
+Include the affected commit, reproduction steps, expected impact, and only the minimum logs or screenshots needed to reproduce the issue, with sensitive filesystem paths and secrets removed.
+
+If private vulnerability reporting is unavailable, open a public issue containing no sensitive details and ask the maintainer to establish a private reporting channel.
+
+## Triage process
+
+- Initial acknowledgement target: within 3 business days.
+- Initial severity and scope assessment target: within 7 business days.
+- Valid reports are reproduced when practical and tracked privately until a fix or mitigation is available.
+- Critical and high-impact issues are prioritized over feature work.
+- Public disclosure should wait until affected users have a reasonable opportunity to update.
+
+These are response targets, not a guarantee of a specific remediation date.
+
+## Security scope
+
+In scope:
+
+- filesystem traversal and path handling;
+- Trash operations and stale filesystem state;
+- macOS privacy boundaries, TCC, Full Disk Access, entitlements, and code-signing configuration;
+- dependency and build-toolchain risks introduced by this repository;
+- GitHub Actions, required checks, secret exposure, and supply-chain integrity;
+- future signing, packaging, release provenance, and update integrity when binary distribution is introduced.
+
+Generally out of scope unless DiskUsage directly causes or amplifies the issue:
+
+- vulnerabilities in macOS, GitHub, Xcode, or other third-party infrastructure;
+- social engineering or phishing;
+- denial-of-service requiring unrealistic local resource exhaustion;
+- issues that require an already fully compromised user account or operating system and do not cross an additional DiskUsage trust boundary.
+
+## Security model
+
+DiskUsage intentionally minimizes attack surface:
+
+- local-only operation with no backend, account, telemetry, advertising, or routine network access;
+- Apple system frameworks only at runtime;
+- user-controlled macOS Full Disk Access;
+- destructive operations limited to moving the explicitly selected item to Trash;
+- protected default branch and PR-based changes;
+- SHA-pinned external GitHub Actions;
+- least-privilege workflow permissions;
+- CodeQL analysis for Swift and GitHub Actions;
+- Gitleaks secret scanning;
+- Dependency Review for dependency/workflow changes;
+- Dependabot updates for GitHub Actions;
+- CI build and regression-test gates.
+
+Never commit signing identities, private keys, certificates with private material, API tokens, `.env` files, provisioning profiles containing sensitive material, or other credentials.


### PR DESCRIPTION
Repository-wide security hardening adapted to DiskUsage's actual Swift/macOS, source-only model.

## Added
- CodeQL for Swift and GitHub Actions workflows.
- Gitleaks secret scanning.
- Dependency Review for dependency/workflow changes.
- Dependabot updates for GitHub Actions.
- Deterministic Actions supply-chain policy: all external actions must be pinned to full commit SHAs; `pull_request_target` is rejected; top-level workflow permissions must default to `{}`.
- `SECURITY.md` with private-reporting guidance, scope, triage targets, and the current source-only support model.
- `.gitignore` coverage for local secret/signing material.
- Repository/CI security and future release-integrity invariants in `AGENTS.md`.

## Hardened
- Existing macOS CI now uses immutable `actions/checkout` pin, `persist-credentials: false`, explicit least-privilege permissions, concurrency cancellation, and a timeout.
- Repository Actions policy requires full-SHA pins, allows only GitHub-owned Actions plus Gitleaks, and defaults `GITHUB_TOKEN` to read-only.
- GitHub secret scanning and push protection are enabled.
- Dependency Graph/vulnerability alerts and Dependabot security updates are enabled.
- Private Vulnerability Reporting is enabled.
- Repository merge policy is squash-only; merged branches are auto-deleted and branch updates are allowed.

## Verification
On the pre-policy-doc head, macOS CI, Actions Policy, Gitleaks, CodeQL Swift, CodeQL Actions, and Dependency Review all passed after enabling Dependency Graph. The final head re-runs the same gates after the `AGENTS.md` policy addition; Security and Dependency Review are already green while macOS/CodeQL are completing.

## Intentionally not added
- No package-manager vulnerability scanner: the app has no SwiftPM/Gradle/npm/Cargo/pip/runtime third-party dependency graph; GitHub Actions are the current dependency surface and are covered by Dependency Review + Dependabot + immutable pin policy.
- No Semgrep/SwiftLint/Qodana gate solely for score: CodeQL provides the relevant Swift SAST layer without adding a low-signal toolchain dependency.
- No release workflow, signing secrets, artifact attestation, or `v*` tag ruleset yet: README states distribution is source-only and there are no release artifacts to attest. These become required when signed/notarized binary releases begin.

## Final repository ruleset step
After the final head is fully green, update `Protect main` to require the observed checks (`macos`, `Actions Policy`, `Gitleaks`, `CodeQL Swift`, `CodeQL Actions`, `Dependency Review`), squash-only linear history, and required signatures; also add a CodeQL code-scanning rule with `medium_or_higher` security threshold. This is deliberately applied only after the exact check names have been observed on real runs.