### PR TITLE
R1.1: preprocess Tree presentation off the UI path

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1,11 +1,41 @@
 import SwiftUI
 import AppKit
 
+@MainActor
+final class TreePresentationState: ObservableObject {
+    @Published private(set) var items: [FolderUsage] = []
+
+    private var task: Task<Void, Never>?
+    private var generation = 0
+
+    func prepare(_ source: [FolderUsage], by option: SortOption) {
+        generation &+= 1
+        let generation = generation
+        task?.cancel()
+
+        guard !source.isEmpty else {
+            task = nil
+            items = []
+            return
+        }
+
+        task = Task.detached(priority: .userInitiated) { [source, option] in
+            guard let prepared = TreePresentationPreprocessor.sorted(source, by: option) else { return }
+
+            await MainActor.run { [weak self] in
+                guard let self, self.generation == generation else { return }
+                self.items = prepared
+                self.task = nil
+            }
+        }
+    }
+}
+
 struct ContentView: View {
     @StateObject var viewModel: DiskScannerViewModel
     @EnvironmentObject var settings: AppSettings
+    @StateObject private var treePresentation = TreePresentationState()
     @State private var sortOption: SortOption = .sizeDesc
-    @State private var sortedItems: [FolderUsage] = []
     @State private var itemToDelete: FolderUsage?
     @State private var showDeleteAlert = false
     @State private var showErrorAlert = false
@@ -26,7 +56,7 @@ struct ContentView: View {
                 switch settings.viewMode {
                 case .tree:
                     TreeView(
-                        items: sortedItems,
+                        items: treePresentation.items,
                         totalSize: viewModel.totalSize,
                         restricted: viewModel.restricted,
                         onShowInFinder: viewModel.showInFinder,
@@ -51,14 +81,14 @@ struct ContentView: View {
         }
         .padding()
         .frame(minWidth: 800, minHeight: 600)
+        .onAppear {
+            treePresentation.prepare(viewModel.items, by: sortOption)
+        }
         .onChange(of: viewModel.items) { _, items in
-            refreshSortedItems(items)
+            treePresentation.prepare(items, by: sortOption)
         }
-        .onChange(of: sortOption) { _, _ in
-            refreshSortedItems(viewModel.items)
-        }
-        .onChange(of: settings.viewMode) { _, _ in
-            refreshSortedItems(viewModel.items)
+        .onChange(of: sortOption) { _, option in
+            treePresentation.prepare(viewModel.items, by: option)
         }
         .alert(
             String(localized: "alert.delete.title", defaultValue: "Move to Trash?"),
@@ -89,14 +119,6 @@ struct ContentView: View {
         } message: {
             Text(errorMessage)
         }
-    }
-
-    private func refreshSortedItems(_ items: [FolderUsage]) {
-        guard settings.viewMode == .tree else {
-            sortedItems = []
-            return
-        }
-        sortedItems = sortOption.sorted(items.map { $0.sorted(by: sortOption) })
     }
 
     private func requestDelete(_ item: FolderUsage) {

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import AppKit
+import Combine
 
 @MainActor
 final class TreePresentationState: ObservableObject {

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -29,6 +29,12 @@ final class TreePresentationState: ObservableObject {
             }
         }
     }
+
+    func cancel() {
+        generation &+= 1
+        task?.cancel()
+        task = nil
+    }
 }
 
 struct ContentView: View {
@@ -81,14 +87,14 @@ struct ContentView: View {
         }
         .padding()
         .frame(minWidth: 800, minHeight: 600)
-        .onAppear {
-            treePresentation.prepare(viewModel.items, by: sortOption)
-        }
-        .onChange(of: viewModel.items) { _, items in
+        .onReceive(viewModel.$items) { items in
             treePresentation.prepare(items, by: sortOption)
         }
         .onChange(of: sortOption) { _, option in
             treePresentation.prepare(viewModel.items, by: option)
+        }
+        .onDisappear {
+            treePresentation.cancel()
         }
         .alert(
             String(localized: "alert.delete.title", defaultValue: "Move to Trash?"),

--- a/DiskUsageTests/FolderUsageTests.swift
+++ b/DiskUsageTests/FolderUsageTests.swift
@@ -48,6 +48,21 @@ final class FolderUsageTests: XCTestCase {
         XCTAssertEqual(SortOption.sizeAsc.sorted([b, a]).map(\.path), [a.path, b.path])
     }
 
+    func testTreePresentationPreprocessorSortsEveryLevelWithoutChangingSource() {
+        let small = FolderUsage(path: "/root/a/small", size: 10, isFile: true)
+        let large = FolderUsage(path: "/root/a/large", size: 90, isFile: true)
+        let largerFolder = FolderUsage(path: "/root/a", size: 100, children: [small, large])
+        let smallerFolder = FolderUsage(path: "/root/b", size: 50)
+        let source = [smallerFolder, largerFolder]
+
+        let prepared = TreePresentationPreprocessor.sorted(source, by: .sizeDesc)
+
+        XCTAssertEqual(prepared?.map(\.path), [largerFolder.path, smallerFolder.path])
+        XCTAssertEqual(prepared?.first?.children.map(\.path), [large.path, small.path])
+        XCTAssertEqual(source.map(\.path), [smallerFolder.path, largerFolder.path])
+        XCTAssertEqual(source[1].children.map(\.path), [small.path, large.path])
+    }
+
     func testFormatBytesUsesNextUnitAtExactBoundary() {
         XCTAssertEqual(formatBytes(1024), "1.0 KB")
     }

--- a/Utilities.swift
+++ b/Utilities.swift
@@ -59,3 +59,44 @@ nonisolated enum SortOption: String, CaseIterable, Identifiable, Sendable {
         }
     }
 }
+
+nonisolated enum TreePresentationPreprocessor {
+    static func sorted(_ items: [FolderUsage], by option: SortOption) -> [FolderUsage]? {
+        guard !isCancelled else { return nil }
+
+        var prepared: [FolderUsage] = []
+        prepared.reserveCapacity(items.count)
+        for item in items {
+            guard let sortedItem = sorted(item, by: option) else { return nil }
+            prepared.append(sortedItem)
+        }
+
+        guard !isCancelled else { return nil }
+        return option.sorted(prepared)
+    }
+
+    private static func sorted(_ item: FolderUsage, by option: SortOption) -> FolderUsage? {
+        guard !isCancelled else { return nil }
+
+        var children: [FolderUsage] = []
+        children.reserveCapacity(item.children.count)
+        for child in item.children {
+            guard let sortedChild = sorted(child, by: option) else { return nil }
+            children.append(sortedChild)
+        }
+
+        guard !isCancelled else { return nil }
+        return FolderUsage(
+            path: item.path,
+            size: item.size,
+            isFile: item.isFile,
+            children: option.sorted(children)
+        )
+    }
+
+    private static var isCancelled: Bool {
+        withUnsafeCurrentTask { task in
+            task?.isCancelled ?? false
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements **R1.1 — Tree presentation preprocessing** from `docs/ROADMAP.md`.

The authoritative `FolderUsage` scan snapshot is unchanged. Recursive Tree sorting is now derived in a cancellable detached task and only the latest generation may publish back to the main actor. `ContentView` listens to the `@Published` item stream instead of using deep `Equatable` change detection on the whole tree.

## Roadmap alignment

Roadmap stage/slice: **R1 / R1.1**

- This PR is limited to the current R1.1 slice.
- No R2 Zen visual redesign work is included.
- No filesystem traversal, allocated-size, Trash, Sunburst, entitlement, release, or dependency behavior changes.

## Correctness and stale suppression

- `FolderUsage` remains authoritative and immutable.
- Derived ordering preserves existing `SortOption` semantics and deterministic path tie-breaking.
- A generation token prevents an older sort task from overwriting a newer scan/sort result.
- Superseded preparation is cancelled and recursive preprocessing checks task cancellation.
- View disappearance cancels outstanding preparation.

## Performance evidence

Before: every `viewModel.items` / sort / view-mode refresh synchronously executed a recursive whole-tree transform from `ContentView`, and `.onChange(of: viewModel.items)` could also require deep `Equatable` comparison.

After: recursive presentation preparation runs off the main actor only when the published scan snapshot or selected sort option changes. Ordinary SwiftUI body recomputation and view-mode switching no longer trigger whole-tree sorting; item publication is observed through `@Published` rather than whole-tree equality comparison.

This is structural evidence for R1.1; R1.4 will add broader repeatable performance fixtures for the full R1 stage.

## Tests

Adds regression coverage proving derived preprocessing sorts every hierarchy level deterministically without mutating the source snapshot.

Closes #13. Tracks #10.