### PR TITLE
Platform: migrate DiskUsage to Swift 6 language mode

### DIFF
--- a/DiskScannerViewModel.swift
+++ b/DiskScannerViewModel.swift
@@ -92,7 +92,10 @@ final class DiskScannerViewModel: ObservableObject {
             }
         }
 
-        let workerTask = Task.detached(priority: .userInitiated) {
+        let workerTask = Task.detached(priority: .userInitiated) { () -> (
+            result: (root: FolderUsage, restricted: [String]),
+            progress: ScanProgress
+        )? in
             let result = await scanner.scan(at: url, showHiddenFiles: showHiddenFiles)
             guard !Task.isCancelled else { return nil }
             return (result: result, progress: scanner.progress)

--- a/DiskScannerViewModel.swift
+++ b/DiskScannerViewModel.swift
@@ -92,15 +92,24 @@ final class DiskScannerViewModel: ObservableObject {
             }
         }
 
-        scanTask = Task.detached(priority: .userInitiated) { [weak self] in
+        let workerTask = Task.detached(priority: .userInitiated) {
             let result = await scanner.scan(at: url, showHiddenFiles: showHiddenFiles)
-            guard !Task.isCancelled else { return }
-            let finalProgress = scanner.progress
+            guard !Task.isCancelled else { return nil }
+            return (result: result, progress: scanner.progress)
+        }
 
-            await MainActor.run {
-                guard let self, self.scanGeneration == generation else { return }
-                self.finishScan(result, progress: finalProgress)
+        scanTask = Task { [weak self] in
+            let output = await withTaskCancellationHandler {
+                await workerTask.value
+            } onCancel: {
+                workerTask.cancel()
             }
+
+            guard !Task.isCancelled,
+                  let output,
+                  let self,
+                  self.scanGeneration == generation else { return }
+            self.finishScan(output.result, progress: output.progress)
         }
     }
 

--- a/DiskUsage.xcodeproj/project.pbxproj
+++ b/DiskUsage.xcodeproj/project.pbxproj
@@ -10,7 +10,7 @@
 		09164F04B93E700E14A4D81A /* FolderUsageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8D41F1654CD51C1A4530EB /* FolderUsageTests.swift */; };
 		0D2D7CB139CF0C3BAD5061D9 /* DiskScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE120206D5311A58B609EA26 /* DiskScannerTests.swift */; };
 		950FB98D2EE0B874003A2FC2 /* DiskUsageApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950FB98C2EE0B874003A2FC2 /* DiskUsageApp.swift */; };
-		950FB9912EE0B875003A2FC2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 950FB9902EE0B875003A2FC2 /* Assets.xcassets */; };
+		950FB9912EE0B875003A2FC2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 950FB9902EE0B874003A2FC2 /* Assets.xcassets */; };
 		950FB9982EE0B9CB003A2FC2 /* FolderUsage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950FB9972EE0B9C7003A2FC2 /* FolderUsage.swift */; };
 		950FB99C2EE0B9FC003A2FC2 /* DiskScannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950FB99B2EE0B9F8003A2FC2 /* DiskScannerViewModel.swift */; };
 		950FB99E2EE0BA5B003A2FC2 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950FB99D2EE0BA15003A2FC2 /* ContentView.swift */; };
@@ -77,7 +77,7 @@
 				950FB9A02EE0B874003A2FC2 /* DiskUsage.app */,
 				3DAB7E54CE6A4A0214818007 /* DiskUsageTests.xctest */,
 				950FB9B32EE4433A003A2FC2 /* DiskUsage.entitlements */,
-				950FB99D2EE0BA15003A2FC2 /* ContentView.swift */,
+				950FB99D2EE0BA5B003A2FC2 /* ContentView.swift */,
 				950FB9B82EE4568B003A2FC2 /* DiskScanner.swift */,
 				950FB99B2EE0B9F8003A2FC2 /* DiskScannerViewModel.swift */,
 				950FB98C2EE0B874003A2FC2 /* DiskUsageApp.swift */,
@@ -249,7 +249,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sl.DiskUsageTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DiskUsage.app/Contents/MacOS/DiskUsage";
 			};
 			name = Release;
@@ -405,7 +405,7 @@
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Debug;
 		};
@@ -438,7 +438,7 @@
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};
@@ -450,7 +450,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.sl.DiskUsageTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 6.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DiskUsage.app/Contents/MacOS/DiskUsage";
 			};
 			name = Debug;


### PR DESCRIPTION
## Summary

Priority platform-baseline slice approved by the project owner before R1.2.

Migrates both the DiskUsage app target and DiskUsageTests target from Swift 5 language mode to Swift 6 language mode. No product/UI/filesystem behavior is intentionally changed.

## Scope

- `SWIFT_VERSION = 6.0` for Debug/Release app configurations.
- `SWIFT_VERSION = 6.0` for Debug/Release test configurations.
- Preserve MainActor default isolation and approachable concurrency.
- Fix only compile/concurrency issues exposed by Swift 6; do not weaken Sendable or actor-safety checks.

## Verification

Required: macOS Debug tests, Release build, Security, Dependency Review, CodeQL Swift/Actions.

Closes #17.