### PR TITLE
R1.2: preprocess Sunburst presentation off the UI path

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -42,6 +42,7 @@ struct ContentView: View {
     @StateObject var viewModel: DiskScannerViewModel
     @EnvironmentObject var settings: AppSettings
     @StateObject private var treePresentation = TreePresentationState()
+    @StateObject private var sunburstPresentation = SunburstPresentationState()
     @State private var sortOption: SortOption = .sizeDesc
     @State private var itemToDelete: FolderUsage?
     @State private var showDeleteAlert = false
@@ -72,8 +73,7 @@ struct ContentView: View {
                     )
                 case .sunburst:
                     SunburstView(
-                        items: viewModel.items,
-                        totalSize: viewModel.totalSize,
+                        state: sunburstPresentation,
                         scanProgress: viewModel.isScanning ? viewModel.progress : nil,
                         onShowInFinder: viewModel.showInFinder,
                         onCopyPath: viewModel.copyPath,
@@ -91,11 +91,24 @@ struct ContentView: View {
         .onReceive(viewModel.$items) { items in
             treePresentation.prepare(items, by: sortOption)
         }
+        .onReceive(viewModel.$items.combineLatest(viewModel.$totalSize)) { items, totalSize in
+            guard settings.viewMode == .sunburst else { return }
+            sunburstPresentation.updateSource(items, totalSize: totalSize)
+        }
         .onChange(of: sortOption) { _, option in
             treePresentation.prepare(viewModel.items, by: option)
         }
+        .onChange(of: settings.viewMode) { _, mode in
+            switch mode {
+            case .tree:
+                sunburstPresentation.cancel()
+            case .sunburst:
+                sunburstPresentation.updateSource(viewModel.items, totalSize: viewModel.totalSize)
+            }
+        }
         .onDisappear {
             treePresentation.cancel()
+            sunburstPresentation.cancel()
         }
         .alert(
             String(localized: "alert.delete.title", defaultValue: "Move to Trash?"),

--- a/DiskUsageTests/FolderUsageTests.swift
+++ b/DiskUsageTests/FolderUsageTests.swift
@@ -104,8 +104,9 @@ final class FolderUsageTests: XCTestCase {
     }
 
     func testSunburstPresentationPreprocessorPreservesDepthCapAndMinimumSpan() {
-        let deepest = FolderUsage(path: "/root/a/b/c/d", size: 100, isFile: true)
-        let levelThree = FolderUsage(path: "/root/a/b/c", size: 100, children: [deepest])
+        let beyondDepth = FolderUsage(path: "/root/a/b/c/d/e", size: 100, isFile: true)
+        let levelFour = FolderUsage(path: "/root/a/b/c/d", size: 100, children: [beyondDepth])
+        let levelThree = FolderUsage(path: "/root/a/b/c", size: 100, children: [levelFour])
         let levelTwo = FolderUsage(path: "/root/a/b", size: 100, children: [levelThree])
         let levelOne = FolderUsage(path: "/root/a", size: 100, children: [levelTwo])
         let tiny = FolderUsage(path: "/root/tiny", size: 1, isFile: true)
@@ -123,7 +124,11 @@ final class FolderUsageTests: XCTestCase {
         )
 
         XCTAssertEqual(depthPrepared?.segments.map(\.level), [0, 1, 2, 3])
-        XCTAssertFalse(depthPrepared?.segments.contains(where: { $0.path == deepest.path }) == true)
+        XCTAssertEqual(
+            depthPrepared?.segments.map(\.path),
+            [levelOne.path, levelTwo.path, levelThree.path, levelFour.path]
+        )
+        XCTAssertFalse(depthPrepared?.segments.contains(where: { $0.path == beyondDepth.path }) == true)
         XCTAssertEqual(filteredPrepared?.segments.map(\.path), [large.path])
     }
 

--- a/DiskUsageTests/FolderUsageTests.swift
+++ b/DiskUsageTests/FolderUsageTests.swift
@@ -63,6 +63,70 @@ final class FolderUsageTests: XCTestCase {
         XCTAssertEqual(source[1].children.map(\.path), [small.path, large.path])
     }
 
+    func testSunburstPresentationPreprocessorIsDeterministicAndDoesNotMutateSource() {
+        let zChild = FolderUsage(path: "/root/a/z", size: 25, isFile: true)
+        let aChild = FolderUsage(path: "/root/a/a", size: 25, isFile: true)
+        let folderB = FolderUsage(path: "/root/b", size: 50)
+        let folderA = FolderUsage(path: "/root/a", size: 50, children: [zChild, aChild])
+        let source = [folderB, folderA]
+
+        let prepared = SunburstPresentationPreprocessor.prepare(
+            items: source,
+            totalSize: 100,
+            navigation: []
+        )
+
+        let topLevel = prepared?.segments.filter { $0.level == 0 }
+        let nested = prepared?.segments.filter { $0.level == 1 }
+
+        XCTAssertEqual(topLevel?.map(\.path), [folderA.path, folderB.path])
+        XCTAssertEqual(nested?.map(\.path), [aChild.path, zChild.path])
+        XCTAssertEqual(topLevel?.map(\.startAngle), [0, 180])
+        XCTAssertEqual(topLevel?.map(\.endAngle), [180, 360])
+        XCTAssertEqual(source.map(\.path), [folderB.path, folderA.path])
+        XCTAssertEqual(source[1].children.map(\.path), [zChild.path, aChild.path])
+    }
+
+    func testSunburstPresentationPreprocessorResolvesNavigation() {
+        let leaf = FolderUsage(path: "/root/folder/leaf", size: 100, isFile: true)
+        let folder = FolderUsage(path: "/root/folder", size: 100, children: [leaf])
+
+        let prepared = SunburstPresentationPreprocessor.prepare(
+            items: [folder],
+            totalSize: 100,
+            navigation: [folder.path]
+        )
+
+        XCTAssertEqual(prepared?.navigation.map(\.path), [folder.path])
+        XCTAssertEqual(prepared?.total, folder.size)
+        XCTAssertEqual(prepared?.segments.map(\.path), [leaf.path])
+        XCTAssertEqual(prepared?.segments.map(\.level), [0])
+    }
+
+    func testSunburstPresentationPreprocessorPreservesDepthCapAndMinimumSpan() {
+        let deepest = FolderUsage(path: "/root/a/b/c/d", size: 100, isFile: true)
+        let levelThree = FolderUsage(path: "/root/a/b/c", size: 100, children: [deepest])
+        let levelTwo = FolderUsage(path: "/root/a/b", size: 100, children: [levelThree])
+        let levelOne = FolderUsage(path: "/root/a", size: 100, children: [levelTwo])
+        let tiny = FolderUsage(path: "/root/tiny", size: 1, isFile: true)
+        let large = FolderUsage(path: "/root/large", size: 999, isFile: true)
+
+        let depthPrepared = SunburstPresentationPreprocessor.prepare(
+            items: [levelOne],
+            totalSize: 100,
+            navigation: []
+        )
+        let filteredPrepared = SunburstPresentationPreprocessor.prepare(
+            items: [tiny, large],
+            totalSize: 1_000,
+            navigation: []
+        )
+
+        XCTAssertEqual(depthPrepared?.segments.map(\.level), [0, 1, 2, 3])
+        XCTAssertFalse(depthPrepared?.segments.contains(where: { $0.path == deepest.path }) == true)
+        XCTAssertEqual(filteredPrepared?.segments.map(\.path), [large.path])
+    }
+
     func testFormatBytesUsesNextUnitAtExactBoundary() {
         XCTAssertEqual(formatBytes(1024), "1.0 KB")
     }

--- a/SunburstView.swift
+++ b/SunburstView.swift
@@ -1,31 +1,264 @@
 import SwiftUI
+import Combine
+
+nonisolated struct SunburstBreadcrumb: Identifiable, Equatable, Sendable {
+    let path: String
+    let name: String
+
+    var id: String { path }
+}
+
+nonisolated struct SunburstSegment: Identifiable, Equatable, Sendable {
+    let path: String
+    let size: Int64
+    let isFile: Bool
+    let hasChildren: Bool
+    let level: Int
+    let startAngle: Double
+    let endAngle: Double
+    let hue: Double
+
+    var id: String { "\(path)-\(level)" }
+
+    var item: FolderUsage {
+        FolderUsage(path: path, size: size, isFile: isFile)
+    }
+}
+
+nonisolated struct SunburstPresentation: Equatable, Sendable {
+    let navigation: [SunburstBreadcrumb]
+    let total: Int64
+    let segments: [SunburstSegment]
+
+    static let empty = SunburstPresentation(navigation: [], total: 0, segments: [])
+}
+
+nonisolated enum SunburstPresentationPreprocessor {
+    static func prepare(
+        items: [FolderUsage],
+        totalSize: Int64,
+        navigation: [String],
+        levels: Int = 4,
+        minimumSpan: Double = 1
+    ) -> SunburstPresentation? {
+        guard !isCancelled else { return nil }
+
+        var candidates = items
+        var resolvedNavigation: [SunburstBreadcrumb] = []
+        var currentItem: FolderUsage?
+
+        for path in navigation {
+            guard !isCancelled else { return nil }
+            guard let item = candidates.first(where: { $0.path == path }) else { break }
+            resolvedNavigation.append(SunburstBreadcrumb(path: item.path, name: item.name))
+            currentItem = item
+            candidates = item.children
+        }
+
+        let currentItems = currentItem?.children ?? items
+        let currentTotal = currentItem?.size ?? totalSize
+        var segments: [SunburstSegment] = []
+
+        guard levels > 0, currentTotal > 0 else {
+            return SunburstPresentation(
+                navigation: resolvedNavigation,
+                total: currentTotal,
+                segments: segments
+            )
+        }
+
+        let sorted = SortOption.sizeDesc.sorted(currentItems)
+        segments.reserveCapacity(sorted.count)
+
+        func build(
+            _ children: [FolderUsage],
+            total: Int64,
+            level: Int,
+            start: Double,
+            end: Double,
+            hue: Double
+        ) -> Bool {
+            guard !isCancelled else { return false }
+            guard level < levels, total > 0 else { return true }
+
+            var angle = start
+            for item in SortOption.sizeDesc.sorted(children) {
+                guard !isCancelled else { return false }
+
+                let span = (end - start) * Double(item.size) / Double(total)
+                let endAngle = angle + span
+                defer { angle = endAngle }
+                guard span >= minimumSpan else { continue }
+
+                segments.append(
+                    SunburstSegment(
+                        path: item.path,
+                        size: item.size,
+                        isFile: item.isFile,
+                        hasChildren: !item.children.isEmpty,
+                        level: level,
+                        startAngle: angle,
+                        endAngle: endAngle,
+                        hue: hue
+                    )
+                )
+
+                if !item.children.isEmpty,
+                   !build(
+                       item.children,
+                       total: item.size,
+                       level: level + 1,
+                       start: angle,
+                       end: endAngle,
+                       hue: hue
+                   ) {
+                    return false
+                }
+            }
+
+            return true
+        }
+
+        var angle = 0.0
+        for (index, item) in sorted.enumerated() {
+            guard !isCancelled else { return nil }
+
+            let span = 360 * Double(item.size) / Double(currentTotal)
+            let endAngle = angle + span
+            defer { angle = endAngle }
+            guard span >= minimumSpan else { continue }
+
+            let hue = (Double(index) / Double(max(sorted.count, 1)) + 0.08)
+                .truncatingRemainder(dividingBy: 1)
+            segments.append(
+                SunburstSegment(
+                    path: item.path,
+                    size: item.size,
+                    isFile: item.isFile,
+                    hasChildren: !item.children.isEmpty,
+                    level: 0,
+                    startAngle: angle,
+                    endAngle: endAngle,
+                    hue: hue
+                )
+            )
+
+            if !item.children.isEmpty,
+               !build(
+                   item.children,
+                   total: item.size,
+                   level: 1,
+                   start: angle,
+                   end: endAngle,
+                   hue: hue
+               ) {
+                return nil
+            }
+        }
+
+        guard !isCancelled else { return nil }
+        return SunburstPresentation(
+            navigation: resolvedNavigation,
+            total: currentTotal,
+            segments: segments
+        )
+    }
+
+    private static var isCancelled: Bool {
+        withUnsafeCurrentTask { task in
+            task?.isCancelled ?? false
+        }
+    }
+}
+
+@MainActor
+final class SunburstPresentationState: ObservableObject {
+    @Published private(set) var presentation: SunburstPresentation = .empty
+
+    private var source: [FolderUsage] = []
+    private var totalSize: Int64 = 0
+    private var navigation: [String] = []
+    private var task: Task<Void, Never>?
+    private var generation = 0
+
+    func updateSource(_ source: [FolderUsage], totalSize: Int64) {
+        self.source = source
+        self.totalSize = totalSize
+        prepare()
+    }
+
+    func drillDown(_ path: String) {
+        navigation.append(path)
+        prepare()
+    }
+
+    func navigateBack() {
+        guard !navigation.isEmpty else { return }
+        navigation.removeLast()
+        prepare()
+    }
+
+    func navigateToRoot() {
+        guard !navigation.isEmpty else { return }
+        navigation.removeAll()
+        prepare()
+    }
+
+    func navigate(toDepth depth: Int) {
+        let depth = min(max(depth, 0), navigation.count)
+        guard depth != navigation.count else { return }
+        navigation = Array(navigation.prefix(depth))
+        prepare()
+    }
+
+    func cancel() {
+        generation &+= 1
+        task?.cancel()
+        task = nil
+    }
+
+    private func prepare() {
+        generation &+= 1
+        let generation = generation
+        task?.cancel()
+
+        guard !source.isEmpty else {
+            task = nil
+            navigation.removeAll()
+            presentation = .empty
+            return
+        }
+
+        let source = source
+        let totalSize = totalSize
+        let navigation = navigation
+
+        task = Task.detached(priority: .userInitiated) { [source, totalSize, navigation] in
+            guard let prepared = SunburstPresentationPreprocessor.prepare(
+                items: source,
+                totalSize: totalSize,
+                navigation: navigation
+            ) else { return }
+
+            await MainActor.run { [weak self] in
+                guard let self, self.generation == generation else { return }
+                self.navigation = prepared.navigation.map(\.path)
+                self.presentation = prepared
+                self.task = nil
+            }
+        }
+    }
+}
 
 struct SunburstView: View {
-    let items: [FolderUsage]
-    let totalSize: Int64
+    @ObservedObject var state: SunburstPresentationState
     var scanProgress: ScanProgress? = nil
     let onShowInFinder: (FolderUsage) -> Void
     let onCopyPath: (FolderUsage) -> Void
     let onDelete: (FolderUsage) -> Void
 
-    @State private var navigation: [String] = []
-
-    private let levels = 4, center: CGFloat = 70, ring: CGFloat = 45
-
-    private var resolvedPath: [FolderUsage] {
-        var candidates = items
-        var result: [FolderUsage] = []
-        for path in navigation {
-            guard let item = candidates.first(where: { $0.path == path }) else { break }
-            result.append(item)
-            candidates = item.children
-        }
-        return result
-    }
-
-    private var current: (items: [FolderUsage], total: Int64) {
-        (resolvedPath.last?.children ?? items, resolvedPath.last?.size ?? totalSize)
-    }
+    private let center: CGFloat = 70
+    private let ring: CGFloat = 45
 
     var body: some View {
         VStack(spacing: 12) {
@@ -33,23 +266,29 @@ struct SunburstView: View {
             GeometryReader { geo in
                 let c = CGPoint(x: geo.size.width / 2, y: geo.size.height / 2)
                 ZStack {
-                    ForEach(segments(), id: \.0) { _, item, level, start, end, color in
+                    ForEach(state.presentation.segments) { segment in
                         let arc = Arc(
                             c: c,
-                            r1: center + CGFloat(level) * ring,
-                            r2: center + CGFloat(level + 1) * ring - 1,
-                            a1: start,
-                            a2: end
+                            r1: center + CGFloat(segment.level) * ring,
+                            r2: center + CGFloat(segment.level + 1) * ring - 1,
+                            a1: segment.startAngle,
+                            a2: segment.endAngle
                         )
+                        let color = Color(
+                            hue: segment.hue,
+                            saturation: 0.7 - Double(segment.level) * 0.08,
+                            brightness: 0.9 - Double(segment.level) * 0.12
+                        )
+
                         arc.fill(color)
                             .overlay(arc.stroke(.white.opacity(0.3), lineWidth: 0.5))
                             .onTapGesture {
-                                if !item.children.isEmpty {
-                                    withAnimation(.easeInOut(duration: 0.3)) { navigation.append(item.path) }
+                                if segment.hasChildren {
+                                    state.drillDown(segment.path)
                                 }
                             }
                             .folderContextMenu(
-                                item,
+                                segment.item,
                                 showHeader: true,
                                 onShowInFinder: onShowInFinder,
                                 onCopyPath: onCopyPath,
@@ -63,7 +302,7 @@ struct SunburstView: View {
                         .position(c)
 
                     VStack(spacing: 4) {
-                        Text(formatBytes(scanProgress?.bytesFound ?? current.total))
+                        Text(formatBytes(scanProgress?.bytesFound ?? state.presentation.total))
                             .font(.system(size: 18, weight: .bold))
                         Text(scanProgress != nil
                              ? String(localized: "sunburst.scanning", defaultValue: "scanning…")
@@ -74,40 +313,43 @@ struct SunburstView: View {
                     .frame(width: center * 1.8)
                     .position(c)
                 }
+                .animation(
+                    .easeInOut(duration: 0.3),
+                    value: state.presentation.navigation.map(\.path)
+                )
             }
         }
         .frame(minWidth: 400, minHeight: 400)
-        .onChange(of: totalSize) { _, _ in navigation = resolvedPath.map(\.path) }
     }
 
     private var breadcrumb: some View {
         HStack(spacing: 8) {
             Button {
-                withAnimation(.easeInOut(duration: 0.3)) { _ = navigation.popLast() }
+                state.navigateBack()
             } label: {
                 Image(systemName: "chevron.left").font(.system(size: 14, weight: .semibold))
             }
             .buttonStyle(.bordered)
-            .disabled(resolvedPath.isEmpty)
+            .disabled(state.presentation.navigation.isEmpty)
 
             HStack(spacing: 4) {
                 Button {
-                    withAnimation(.easeInOut(duration: 0.3)) { navigation.removeAll() }
+                    state.navigateToRoot()
                 } label: {
                     Text(verbatim: "/")
                 }
                 .buttonStyle(.plain)
-                .foregroundStyle(resolvedPath.isEmpty ? .primary : .secondary)
+                .foregroundStyle(state.presentation.navigation.isEmpty ? .primary : .secondary)
 
-                ForEach(Array(resolvedPath.enumerated()), id: \.element.path) { index, item in
+                ForEach(Array(state.presentation.navigation.enumerated()), id: \.element.path) { index, item in
                     Image(systemName: "chevron.right").font(.caption2).foregroundStyle(.secondary)
                     Button(item.name) {
-                        withAnimation(.easeInOut(duration: 0.3)) {
-                            navigation = Array(navigation.prefix(index + 1))
-                        }
+                        state.navigate(toDepth: index + 1)
                     }
                     .buttonStyle(.plain)
-                    .foregroundStyle(index == resolvedPath.count - 1 ? .primary : .secondary)
+                    .foregroundStyle(
+                        index == state.presentation.navigation.count - 1 ? .primary : .secondary
+                    )
                     .lineLimit(1)
                 }
             }
@@ -115,50 +357,6 @@ struct SunburstView: View {
             Spacer()
         }
         .padding(.horizontal)
-    }
-
-    private func segments() -> [(String, FolderUsage, Int, Double, Double, Color)] {
-        var result: [(String, FolderUsage, Int, Double, Double, Color)] = []
-        let sorted = current.items.sorted { $0.size > $1.size }
-
-        func build(_ items: [FolderUsage], _ total: Int64, _ level: Int, _ start: Double, _ end: Double, _ hue: Double) {
-            guard level < levels, total > 0 else { return }
-            var angle = start
-            for item in items.sorted(by: { $0.size > $1.size }) {
-                let span = (end - start) * Double(item.size) / Double(total)
-                let endAngle = angle + span
-                defer { angle = endAngle }
-                guard span >= 1 else { continue }
-
-                result.append((
-                    "\(item.path)-\(level)", item, level, angle, endAngle,
-                    Color(
-                        hue: hue,
-                        saturation: 0.7 - Double(level) * 0.08,
-                        brightness: 0.9 - Double(level) * 0.12
-                    )
-                ))
-                if !item.children.isEmpty {
-                    build(item.children, item.size, level + 1, angle, endAngle, hue)
-                }
-            }
-        }
-
-        guard current.total > 0 else { return result }
-        var angle = 0.0
-        for (index, item) in sorted.enumerated() {
-            let span = 360 * Double(item.size) / Double(current.total)
-            let endAngle = angle + span
-            defer { angle = endAngle }
-            guard span >= 1 else { continue }
-
-            let hue = (Double(index) / Double(max(sorted.count, 1)) + 0.08).truncatingRemainder(dividingBy: 1)
-            result.append((item.path + "-0", item, 0, angle, endAngle, Color(hue: hue, saturation: 0.7, brightness: 0.9)))
-            if !item.children.isEmpty {
-                build(item.children, item.size, 1, angle, endAngle, hue)
-            }
-        }
-        return result
     }
 }
 


### PR DESCRIPTION
## Summary

Implements **R1.2 — Sunburst presentation preprocessing** from `docs/ROADMAP.md`.

The authoritative `FolderUsage` snapshot is unchanged. Sunburst recursive sorting and segment preparation move out of ordinary SwiftUI body evaluation into a cancellable detached preprocessing task. SwiftUI-only color/path construction remains on the UI side.

## Roadmap alignment

Roadmap stage/slice: **R1 / R1.2**

- no R1.3 completed-scan summary work;
- no R2 Zen redesign;
- no filesystem traversal, Trash, entitlement, dependency, release, or project-baseline changes.

## Architecture

- lightweight `Sendable` breadcrumb/segment descriptors carry only presentation values;
- `SunburstPresentationPreprocessor` resolves navigation, applies deterministic size/path ordering, enforces the existing four-level cap and one-degree minimum span, and checks task cancellation;
- `SunburstPresentationState` owns only derived presentation state plus its current source/navigation inputs;
- generation tokens prevent superseded work from publishing stale results;
- `ContentView` drives source updates from `$items.combineLatest($totalSize)` instead of deep `[FolderUsage]` equality;
- preparation is lazy: source updates are processed only while Sunburst is selected, and pending Sunburst work is cancelled when switching to Tree or leaving the view.

## Performance evidence

Before: every ordinary `SunburstView.body` evaluation called `segments()`, which recursively sorted visible hierarchy levels and rebuilt the complete segment graph synchronously on the UI path.

After: ordinary body evaluation iterates a previously prepared segment array. Recursive sorting/segment construction runs only after relevant scan snapshot/total or Sunburst navigation changes, off the main actor, with cancellation/stale suppression.

This is structural R1.2 evidence; broader repeatable synthetic measurements remain R1.4.

## Tests

Focused regression coverage verifies:
- deterministic path tie-breaking at top and nested levels;
- source immutability;
- navigation resolution;
- existing four-level visibility cap;
- existing one-degree minimum-span filtering.

The first CI run exposed only an incorrect depth-cap test fixture: the fixture treated visible level 3 as out of range. The test was corrected by adding a fifth node beyond the four visible levels; no production code changed in that fix.

## Exact-head verification (`af16ff340a645493bd6d7824bafcf026afdd2d53`)

- Xcode 26.6 / Swift 6 Debug tests: **PASS**
- Release build: **PASS**
- Security: **PASS**
- Dependency Review: **PASS**
- CodeQL Actions: **PASS**
- CodeQL Swift: required before merge; currently running

Closes #22. Tracks #10.