### PR TITLE
R1.2: preprocess Sunburst presentation off the UI path

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -74,6 +74,7 @@ struct ContentView: View {
                     SunburstView(
                         items: viewModel.items,
                         totalSize: viewModel.totalSize,
+                        snapshotRevision: viewModel.snapshotRevision,
                         scanProgress: viewModel.isScanning ? viewModel.progress : nil,
                         onShowInFinder: viewModel.showInFinder,
                         onCopyPath: viewModel.copyPath,

--- a/DiskScannerViewModel.swift
+++ b/DiskScannerViewModel.swift
@@ -30,6 +30,7 @@ final class DiskScannerViewModel: ObservableObject {
     @Published private(set) var totalSize: Int64 = 0
     @Published private(set) var progress = ScanProgress()
     @Published private(set) var diskInfo: DiskInfo = .empty
+    private(set) var snapshotRevision: UInt64 = 0
 
     private let settings: AppSettings
     private var scanTask: Task<Void, Never>?
@@ -78,11 +79,12 @@ final class DiskScannerViewModel: ObservableObject {
 
         isScanning = true
         targetDescription = description ?? url.path
-        items = []
         restricted = []
         totalSize = 0
         progress = ScanProgress()
         status = String(localized: "status.scanning", defaultValue: "Scanning…")
+        snapshotRevision &+= 1
+        items = []
 
         progressTask = Task { [weak self] in
             while !Task.isCancelled {
@@ -132,10 +134,11 @@ final class DiskScannerViewModel: ObservableObject {
         progressTask = nil
         scanTask = nil
         progress = finalProgress
-        items = result.root.children
         totalSize = result.root.size
         restricted = result.restricted
         isScanning = false
+        snapshotRevision &+= 1
+        items = result.root.children
 
         status = items.isEmpty
             ? String(localized: "status.finished.empty", defaultValue: "No data found.")
@@ -170,9 +173,11 @@ final class DiskScannerViewModel: ObservableObject {
 
         do {
             try FileManager.default.trashItem(at: item.url, resultingItemURL: nil)
-            items = items.compactMap { $0.removing(path: item.path) }
+            let updatedItems = items.compactMap { $0.removing(path: item.path) }
             totalSize -= size
             status = String(localized: "status.trashed", defaultValue: "Moved to Trash.")
+            snapshotRevision &+= 1
+            items = updatedItems
             updateDiskInfo()
             return .success
         } catch {

--- a/DiskUsageTests/FolderUsageTests.swift
+++ b/DiskUsageTests/FolderUsageTests.swift
@@ -63,6 +63,44 @@ final class FolderUsageTests: XCTestCase {
         XCTAssertEqual(source[1].children.map(\.path), [small.path, large.path])
     }
 
+    func testSunburstPresentationPreprocessorBuildsDeterministicGeometry() {
+        let childSmall = FolderUsage(path: "/root/a/small", size: 20, isFile: true)
+        let childLarge = FolderUsage(path: "/root/a/large", size: 40, isFile: true)
+        let a = FolderUsage(path: "/root/a", size: 60, children: [childSmall, childLarge])
+        let b = FolderUsage(path: "/root/b", size: 40)
+
+        let prepared = SunburstPresentationPreprocessor.segments(
+            for: [b, a],
+            totalSize: 100,
+            levels: 4
+        )
+
+        let segments = try! XCTUnwrap(prepared)
+        XCTAssertEqual(segments.map(\.item.path), [a.path, childLarge.path, childSmall.path, b.path])
+        XCTAssertEqual(segments.map(\.level), [0, 1, 1, 0])
+        XCTAssertEqual(segments[0].startAngle, 0, accuracy: 0.0001)
+        XCTAssertEqual(segments[0].endAngle, 216, accuracy: 0.0001)
+        XCTAssertEqual(segments[1].startAngle, 0, accuracy: 0.0001)
+        XCTAssertEqual(segments[1].endAngle, 144, accuracy: 0.0001)
+        XCTAssertEqual(segments[2].startAngle, 144, accuracy: 0.0001)
+        XCTAssertEqual(segments[2].endAngle, 216, accuracy: 0.0001)
+        XCTAssertEqual(segments[3].startAngle, 216, accuracy: 0.0001)
+        XCTAssertEqual(segments[3].endAngle, 360, accuracy: 0.0001)
+    }
+
+    func testSunburstPresentationPreprocessorUsesPathTieBreaker() {
+        let b = FolderUsage(path: "/root/b", size: 50)
+        let a = FolderUsage(path: "/root/a", size: 50)
+
+        let prepared = SunburstPresentationPreprocessor.segments(
+            for: [b, a],
+            totalSize: 100,
+            levels: 1
+        )
+
+        XCTAssertEqual(prepared?.map(\.item.path), [a.path, b.path])
+    }
+
     func testFormatBytesUsesNextUnitAtExactBoundary() {
         XCTAssertEqual(formatBytes(1024), "1.0 KB")
     }

--- a/SunburstView.swift
+++ b/SunburstView.swift
@@ -1,13 +1,57 @@
 import SwiftUI
+import Combine
+
+@MainActor
+final class SunburstPresentationState: ObservableObject {
+    @Published private(set) var segments: [SunburstSegment] = []
+
+    private var task: Task<Void, Never>?
+    private var generation = 0
+
+    func prepare(items: [FolderUsage], totalSize: Int64, levels: Int) {
+        generation &+= 1
+        let generation = generation
+        task?.cancel()
+        segments = []
+
+        guard !items.isEmpty, totalSize > 0 else {
+            task = nil
+            return
+        }
+
+        task = Task.detached(priority: .userInitiated) { [items, totalSize, levels] in
+            guard let prepared = SunburstPresentationPreprocessor.segments(
+                for: items,
+                totalSize: totalSize,
+                levels: levels
+            ) else { return }
+
+            await MainActor.run { [weak self] in
+                guard let self, self.generation == generation else { return }
+                self.segments = prepared
+                self.task = nil
+            }
+        }
+    }
+
+    func cancel() {
+        generation &+= 1
+        task?.cancel()
+        task = nil
+        segments = []
+    }
+}
 
 struct SunburstView: View {
     let items: [FolderUsage]
     let totalSize: Int64
+    let snapshotRevision: UInt64
     var scanProgress: ScanProgress? = nil
     let onShowInFinder: (FolderUsage) -> Void
     let onCopyPath: (FolderUsage) -> Void
     let onDelete: (FolderUsage) -> Void
 
+    @StateObject private var presentation = SunburstPresentationState()
     @State private var navigation: [String] = []
 
     private let levels = 4, center: CGFloat = 70, ring: CGFloat = 45
@@ -33,23 +77,31 @@ struct SunburstView: View {
             GeometryReader { geo in
                 let c = CGPoint(x: geo.size.width / 2, y: geo.size.height / 2)
                 ZStack {
-                    ForEach(segments(), id: \.0) { _, item, level, start, end, color in
+                    ForEach(presentation.segments) { segment in
                         let arc = Arc(
                             c: c,
-                            r1: center + CGFloat(level) * ring,
-                            r2: center + CGFloat(level + 1) * ring - 1,
-                            a1: start,
-                            a2: end
+                            r1: center + CGFloat(segment.level) * ring,
+                            r2: center + CGFloat(segment.level + 1) * ring - 1,
+                            a1: segment.startAngle,
+                            a2: segment.endAngle
                         )
+                        let color = Color(
+                            hue: segment.hue,
+                            saturation: 0.7 - Double(segment.level) * 0.08,
+                            brightness: 0.9 - Double(segment.level) * 0.12
+                        )
+
                         arc.fill(color)
                             .overlay(arc.stroke(.white.opacity(0.3), lineWidth: 0.5))
                             .onTapGesture {
-                                if !item.children.isEmpty {
-                                    withAnimation(.easeInOut(duration: 0.3)) { navigation.append(item.path) }
+                                if !segment.item.children.isEmpty {
+                                    withAnimation(.easeInOut(duration: 0.3)) {
+                                        navigation.append(segment.item.path)
+                                    }
                                 }
                             }
                             .folderContextMenu(
-                                item,
+                                segment.item,
                                 showHeader: true,
                                 onShowInFinder: onShowInFinder,
                                 onCopyPath: onCopyPath,
@@ -77,7 +129,18 @@ struct SunburstView: View {
             }
         }
         .frame(minWidth: 400, minHeight: 400)
-        .onChange(of: totalSize) { _, _ in navigation = resolvedPath.map(\.path) }
+        .onAppear {
+            preparePresentation()
+        }
+        .onChange(of: navigation) { _, _ in
+            preparePresentation()
+        }
+        .onChange(of: snapshotRevision) { _, _ in
+            reconcileNavigationAndPrepare()
+        }
+        .onDisappear {
+            presentation.cancel()
+        }
     }
 
     private var breadcrumb: some View {
@@ -117,48 +180,18 @@ struct SunburstView: View {
         .padding(.horizontal)
     }
 
-    private func segments() -> [(String, FolderUsage, Int, Double, Double, Color)] {
-        var result: [(String, FolderUsage, Int, Double, Double, Color)] = []
-        let sorted = current.items.sorted { $0.size > $1.size }
+    private func preparePresentation() {
+        let snapshot = current
+        presentation.prepare(items: snapshot.items, totalSize: snapshot.total, levels: levels)
+    }
 
-        func build(_ items: [FolderUsage], _ total: Int64, _ level: Int, _ start: Double, _ end: Double, _ hue: Double) {
-            guard level < levels, total > 0 else { return }
-            var angle = start
-            for item in items.sorted(by: { $0.size > $1.size }) {
-                let span = (end - start) * Double(item.size) / Double(total)
-                let endAngle = angle + span
-                defer { angle = endAngle }
-                guard span >= 1 else { continue }
-
-                result.append((
-                    "\(item.path)-\(level)", item, level, angle, endAngle,
-                    Color(
-                        hue: hue,
-                        saturation: 0.7 - Double(level) * 0.08,
-                        brightness: 0.9 - Double(level) * 0.12
-                    )
-                ))
-                if !item.children.isEmpty {
-                    build(item.children, item.size, level + 1, angle, endAngle, hue)
-                }
-            }
+    private func reconcileNavigationAndPrepare() {
+        let validNavigation = resolvedPath.map(\.path)
+        if validNavigation == navigation {
+            preparePresentation()
+        } else {
+            navigation = validNavigation
         }
-
-        guard current.total > 0 else { return result }
-        var angle = 0.0
-        for (index, item) in sorted.enumerated() {
-            let span = 360 * Double(item.size) / Double(current.total)
-            let endAngle = angle + span
-            defer { angle = endAngle }
-            guard span >= 1 else { continue }
-
-            let hue = (Double(index) / Double(max(sorted.count, 1)) + 0.08).truncatingRemainder(dividingBy: 1)
-            result.append((item.path + "-0", item, 0, angle, endAngle, Color(hue: hue, saturation: 0.7, brightness: 0.9)))
-            if !item.children.isEmpty {
-                build(item.children, item.size, 1, angle, endAngle, hue)
-            }
-        }
-        return result
     }
 }
 

--- a/Utilities.swift
+++ b/Utilities.swift
@@ -100,3 +100,122 @@ nonisolated enum TreePresentationPreprocessor {
         }
     }
 }
+
+nonisolated struct SunburstSegment: Identifiable, Equatable, Sendable {
+    let id: String
+    let item: FolderUsage
+    let level: Int
+    let startAngle: Double
+    let endAngle: Double
+    let hue: Double
+}
+
+nonisolated enum SunburstPresentationPreprocessor {
+    static func segments(
+        for items: [FolderUsage],
+        totalSize: Int64,
+        levels: Int = 4
+    ) -> [SunburstSegment]? {
+        guard !isCancelled else { return nil }
+        guard totalSize > 0, levels > 0 else { return [] }
+
+        let sorted = sortedBySize(items)
+        var result: [SunburstSegment] = []
+        var angle = 0.0
+
+        for (index, item) in sorted.enumerated() {
+            guard !isCancelled else { return nil }
+
+            let span = 360 * Double(item.size) / Double(totalSize)
+            let endAngle = angle + span
+            defer { angle = endAngle }
+            guard span >= 1 else { continue }
+
+            let hue = (Double(index) / Double(max(sorted.count, 1)) + 0.08)
+                .truncatingRemainder(dividingBy: 1)
+            result.append(
+                SunburstSegment(
+                    id: item.path + "-0",
+                    item: item,
+                    level: 0,
+                    startAngle: angle,
+                    endAngle: endAngle,
+                    hue: hue
+                )
+            )
+
+            guard build(
+                item.children,
+                totalSize: item.size,
+                level: 1,
+                levels: levels,
+                start: angle,
+                end: endAngle,
+                hue: hue,
+                result: &result
+            ) else { return nil }
+        }
+
+        return result
+    }
+
+    private static func build(
+        _ items: [FolderUsage],
+        totalSize: Int64,
+        level: Int,
+        levels: Int,
+        start: Double,
+        end: Double,
+        hue: Double,
+        result: inout [SunburstSegment]
+    ) -> Bool {
+        guard !isCancelled else { return false }
+        guard level < levels, totalSize > 0, !items.isEmpty else { return true }
+
+        var angle = start
+        for item in sortedBySize(items) {
+            guard !isCancelled else { return false }
+
+            let span = (end - start) * Double(item.size) / Double(totalSize)
+            let endAngle = angle + span
+            defer { angle = endAngle }
+            guard span >= 1 else { continue }
+
+            result.append(
+                SunburstSegment(
+                    id: "\(item.path)-\(level)",
+                    item: item,
+                    level: level,
+                    startAngle: angle,
+                    endAngle: endAngle,
+                    hue: hue
+                )
+            )
+
+            guard build(
+                item.children,
+                totalSize: item.size,
+                level: level + 1,
+                levels: levels,
+                start: angle,
+                end: endAngle,
+                hue: hue,
+                result: &result
+            ) else { return false }
+        }
+
+        return true
+    }
+
+    private static func sortedBySize(_ items: [FolderUsage]) -> [FolderUsage] {
+        items.sorted { lhs, rhs in
+            lhs.size != rhs.size ? lhs.size > rhs.size : lhs.path < rhs.path
+        }
+    }
+
+    private static var isCancelled: Bool {
+        withUnsafeCurrentTask { task in
+            task?.isCancelled ?? false
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements **R1.2 — Sunburst presentation preprocessing** from `docs/ROADMAP.md`.

Sunburst segment sorting/construction is no longer performed directly from SwiftUI `body`. Geometry is derived in a cancellable detached task and only the latest generation may publish back to the main actor.

## Roadmap alignment

Roadmap stage/slice: **R1 / R1.2**

- `FolderUsage` remains the only authoritative completed-scan snapshot.
- The new `SunburstSegment` model is presentation-only and `Sendable`.
- A lightweight `snapshotRevision` invalidates presentation work without deep equality checks on the full tree.
- Navigation changes invalidate only derived Sunburst presentation state.
- No R2 Zen visual redesign is included.
- No filesystem traversal, allocated-size, Trash, entitlement, localization, or release behavior changes.

## Correctness and stale suppression

- Superseded preprocessing tasks are cancelled.
- A generation token prevents stale geometry from overwriting newer scan/navigation state.
- Derived segments are cleared while a new presentation is prepared so stale hit targets are not interactive under a newer navigation state.
- Equal-size items use path as a deterministic tie-breaker.
- The existing 1-degree visibility threshold is preserved.

## Performance evidence

Before: `SunburstView.body` called `segments()`, which sorted the current items and recursively sorted and rebuilt visible segment geometry during body evaluation.

After: recursive sorting and segment construction run off the main actor only when the authoritative scan snapshot revision or Sunburst navigation changes. Ordinary body recomputation no longer rebuilds the segment graph.

R1.4 will add the broader repeatable synthetic measurement fixture for the full R1 stage.

## Tests

Adds regression coverage for deterministic root/child ordering and exact expected angular spans.

Closes #26. Tracks #10.