### PR TITLE
R1.3: report truthful completed-scan summary

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -242,9 +242,16 @@ struct ContentView: View {
             Image(systemName: "folder.badge.questionmark")
                 .font(.system(size: 48))
                 .foregroundStyle(.secondary)
-            Text(String(localized: "empty.message", defaultValue: "No data. Start a scan."))
-                .font(.title3)
-                .foregroundStyle(.secondary)
+            Text(
+                viewModel.completedSummary == nil
+                    ? String(localized: "empty.message", defaultValue: "No data. Start a scan.")
+                    : String(
+                        localized: "status.finished.empty",
+                        defaultValue: "No allocated-size items in this scan."
+                    )
+            )
+            .font(.title3)
+            .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/DiskScanner.swift
+++ b/DiskScanner.swift
@@ -1,5 +1,19 @@
 import Foundation
 
+nonisolated struct CompletedScanSummary: Equatable, Sendable {
+    let allocatedBytes: Int64
+    let filesScanned: Int64
+    let foldersScanned: Int64
+    let restrictedLocations: Int
+    let elapsed: Duration
+}
+
+nonisolated struct DiskScanResult: Sendable {
+    let root: FolderUsage
+    let restricted: [String]
+    let summary: CompletedScanSummary
+}
+
 nonisolated final class DiskScanner: @unchecked Sendable {
     private let lock = NSLock()
     private var _progress = ScanProgress()
@@ -19,17 +33,20 @@ nonisolated final class DiskScanner: @unchecked Sendable {
     }
 
     private static let resourceKeys: Set<URLResourceKey> = [
-        .isRegularFileKey, .totalFileAllocatedSizeKey, .fileAllocatedSizeKey
+        .isRegularFileKey, .isDirectoryKey, .totalFileAllocatedSizeKey, .fileAllocatedSizeKey
     ]
 
-    func scan(at rootURL: URL, showHiddenFiles: Bool) async -> (root: FolderUsage, restricted: [String]) {
+    func scan(at rootURL: URL, showHiddenFiles: Bool) async -> DiskScanResult {
         updateProgress(files: 0, bytes: 0, folder: "")
 
+        let clock = ContinuousClock()
+        let startedAt = clock.now
         let rootPath = rootURL.standardizedFileURL.path
         let rootNode = Node(path: rootPath)
         var restricted = Set<String>()
         var entriesSinceYield = 0
         var totalFiles: Int64 = 0
+        var totalFolders: Int64 = 0
         var totalBytes: Int64 = 0
         let options: FileManager.DirectoryEnumerationOptions = showHiddenFiles ? [] : [.skipsHiddenFiles]
 
@@ -43,32 +60,51 @@ nonisolated final class DiskScanner: @unchecked Sendable {
         }
 
         guard let enumerator else {
-            return (FolderUsage(path: rootPath, size: 0), [rootPath])
+            let restrictedPaths = [rootPath]
+            return DiskScanResult(
+                root: FolderUsage(path: rootPath, size: 0),
+                restricted: restrictedPaths,
+                summary: CompletedScanSummary(
+                    allocatedBytes: 0,
+                    filesScanned: 0,
+                    foldersScanned: 0,
+                    restrictedLocations: restrictedPaths.count,
+                    elapsed: startedAt.duration(to: clock.now)
+                )
+            )
         }
 
         while let item = enumerator.nextObject() as? URL {
             if Task.isCancelled { break }
 
             autoreleasepool {
-                guard let values = try? item.resourceValues(forKeys: Self.resourceKeys),
-                      values.isRegularFile == true,
-                      let size = values.totalFileAllocatedSize ?? values.fileAllocatedSize,
-                      size > 0 else { return }
+                guard let values = try? item.resourceValues(forKeys: Self.resourceKeys) else { return }
 
-                let fileSize = Int64(size)
-                let filePath = item.standardizedFileURL.path
-                let folderPath = item.deletingLastPathComponent().standardizedFileURL.path
-                let fileName = (filePath as NSString).lastPathComponent
+                if values.isDirectory == true {
+                    totalFolders += 1
+                    return
+                }
 
-                rootNode.addFile(
-                    path: filePath,
-                    name: fileName,
-                    folder: folderPath,
-                    size: fileSize,
-                    rootPath: rootPath
-                )
+                guard values.isRegularFile == true else { return }
+
                 totalFiles += 1
-                totalBytes += fileSize
+                let folderPath = item.deletingLastPathComponent().standardizedFileURL.path
+
+                if let size = values.totalFileAllocatedSize ?? values.fileAllocatedSize,
+                   size > 0 {
+                    let fileSize = Int64(size)
+                    let filePath = item.standardizedFileURL.path
+                    let fileName = (filePath as NSString).lastPathComponent
+
+                    rootNode.addFile(
+                        path: filePath,
+                        name: fileName,
+                        folder: folderPath,
+                        size: fileSize,
+                        rootPath: rootPath
+                    )
+                    totalBytes += fileSize
+                }
 
                 if totalFiles % 50 == 0 {
                     updateProgress(files: totalFiles, bytes: totalBytes, folder: folderPath)
@@ -83,7 +119,18 @@ nonisolated final class DiskScanner: @unchecked Sendable {
         }
 
         updateProgress(files: totalFiles, bytes: totalBytes, folder: "")
-        return (rootNode.toFolderUsage(), restricted.sorted())
+        let restrictedPaths = restricted.sorted()
+        return DiskScanResult(
+            root: rootNode.toFolderUsage(),
+            restricted: restrictedPaths,
+            summary: CompletedScanSummary(
+                allocatedBytes: totalBytes,
+                filesScanned: totalFiles,
+                foldersScanned: totalFolders,
+                restrictedLocations: restrictedPaths.count,
+                elapsed: startedAt.duration(to: clock.now)
+            )
+        )
     }
 
     private static func topLevelPath(_ url: URL, under root: URL) -> String {

--- a/DiskScannerViewModel.swift
+++ b/DiskScannerViewModel.swift
@@ -30,6 +30,7 @@ final class DiskScannerViewModel: ObservableObject {
     @Published private(set) var totalSize: Int64 = 0
     @Published private(set) var progress = ScanProgress()
     @Published private(set) var diskInfo: DiskInfo = .empty
+    @Published private(set) var completedSummary: CompletedScanSummary?
     private(set) var snapshotRevision: UInt64 = 0
 
     private let settings: AppSettings
@@ -82,6 +83,7 @@ final class DiskScannerViewModel: ObservableObject {
         restricted = []
         totalSize = 0
         progress = ScanProgress()
+        completedSummary = nil
         status = String(localized: "status.scanning", defaultValue: "Scanning…")
         snapshotRevision &+= 1
         items = []
@@ -95,7 +97,7 @@ final class DiskScannerViewModel: ObservableObject {
         }
 
         let workerTask = Task.detached(priority: .userInitiated) { () -> (
-            result: (root: FolderUsage, restricted: [String]),
+            result: DiskScanResult,
             progress: ScanProgress
         )? in
             let result = await scanner.scan(at: url, showHiddenFiles: showHiddenFiles)
@@ -123,13 +125,11 @@ final class DiskScannerViewModel: ObservableObject {
         cancelTasks()
         isScanning = false
         progress = ScanProgress()
+        completedSummary = nil
         status = String(localized: "status.cancelled", defaultValue: "Cancelled.")
     }
 
-    private func finishScan(
-        _ result: (root: FolderUsage, restricted: [String]),
-        progress finalProgress: ScanProgress
-    ) {
+    private func finishScan(_ result: DiskScanResult, progress finalProgress: ScanProgress) {
         progressTask?.cancel()
         progressTask = nil
         scanTask = nil
@@ -137,19 +137,36 @@ final class DiskScannerViewModel: ObservableObject {
         totalSize = result.root.size
         restricted = result.restricted
         isScanning = false
+        completedSummary = result.summary
         snapshotRevision &+= 1
         items = result.root.children
 
-        status = items.isEmpty
-            ? String(localized: "status.finished.empty", defaultValue: "No data found.")
-            : String(
-                format: String(localized: "status.finished", defaultValue: "Found: %@, %lld items."),
-                formatBytes(totalSize),
-                Int64(items.count)
-            )
+        status = String(
+            format: String(
+                localized: "status.finished",
+                defaultValue: "Scanned: %@ · Files: %@ · Folders: %@ · Restricted: %@ · Time: %@"
+            ),
+            formatBytes(result.summary.allocatedBytes),
+            formatNumber(result.summary.filesScanned),
+            formatNumber(result.summary.foldersScanned),
+            formatNumber(Int64(result.summary.restrictedLocations)),
+            formatElapsed(result.summary.elapsed)
+        )
 
         progress = ScanProgress()
         updateDiskInfo()
+    }
+
+    private func formatElapsed(_ duration: Duration) -> String {
+        let totalSeconds = max(Int64(0), duration.components.seconds)
+        let hours = totalSeconds / 3_600
+        let minutes = (totalSeconds % 3_600) / 60
+        let seconds = totalSeconds % 60
+
+        if hours > 0 {
+            return String(format: "%lld:%02lld:%02lld", hours, minutes, seconds)
+        }
+        return String(format: "%lld:%02lld", minutes, seconds)
     }
 
     private func cancelTasks() {
@@ -175,6 +192,7 @@ final class DiskScannerViewModel: ObservableObject {
             try FileManager.default.trashItem(at: item.url, resultingItemURL: nil)
             let updatedItems = items.compactMap { $0.removing(path: item.path) }
             totalSize -= size
+            completedSummary = nil
             status = String(localized: "status.trashed", defaultValue: "Moved to Trash.")
             snapshotRevision &+= 1
             items = updatedItems

--- a/DiskUsageTests/DiskScannerTests.swift
+++ b/DiskUsageTests/DiskScannerTests.swift
@@ -45,6 +45,39 @@ final class DiskScannerTests: XCTestCase {
         XCTAssertGreaterThan(result.root.size, 0)
     }
 
+    func testSummaryCountsRegularFilesDirectoriesAndAllocatedBytesTruthfully() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let populated = root.appendingPathComponent("populated", isDirectory: true)
+        let empty = root.appendingPathComponent("empty", isDirectory: true)
+        try FileManager.default.createDirectory(at: populated, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: empty, withIntermediateDirectories: true)
+
+        let payload = populated.appendingPathComponent("payload.dat")
+        let zero = populated.appendingPathComponent("zero.dat")
+        try Data(repeating: 1, count: 4096).write(to: payload)
+        XCTAssertTrue(FileManager.default.createFile(atPath: zero.path, contents: Data()))
+
+        let zeroValues = try zero.resourceValues(
+            forKeys: [.isRegularFileKey, .totalFileAllocatedSizeKey, .fileAllocatedSizeKey]
+        )
+        XCTAssertEqual(zeroValues.isRegularFile, true)
+        XCTAssertEqual(zeroValues.totalFileAllocatedSize ?? zeroValues.fileAllocatedSize ?? 0, 0)
+
+        let scanner = DiskScanner()
+        let result = await scanner.scan(at: root, showHiddenFiles: true)
+
+        XCTAssertEqual(result.summary.filesScanned, 2)
+        XCTAssertEqual(result.summary.foldersScanned, 2)
+        XCTAssertEqual(result.summary.restrictedLocations, 0)
+        XCTAssertEqual(result.summary.allocatedBytes, result.root.size)
+        XCTAssertGreaterThan(result.summary.allocatedBytes, 0)
+        XCTAssertGreaterThanOrEqual(result.summary.elapsed, .zero)
+        XCTAssertEqual(scanner.progress.filesScanned, result.summary.filesScanned)
+        XCTAssertEqual(scanner.progress.bytesFound, result.summary.allocatedBytes)
+    }
+
     private func makeTemporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/Localizable.xcstrings
+++ b/Localizable.xcstrings
@@ -256,14 +256,14 @@
     },
     "status.finished" : {
       "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "Found: %@, %lld items." } },
-        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Найдено: %@, %lld элементов." } }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Scanned: %@ · Files: %@ · Folders: %@ · Restricted: %@ · Time: %@" } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Просканировано: %@ · Файлы: %@ · Папки: %@ · Без доступа: %@ · Время: %@" } }
       }
     },
     "status.finished.empty" : {
       "localizations" : {
-        "en" : { "stringUnit" : { "state" : "translated", "value" : "No data found." } },
-        "ru" : { "stringUnit" : { "state" : "translated", "value" : "Данные не найдены." } }
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "No allocated-size items in this scan." } },
+        "ru" : { "stringUnit" : { "state" : "translated", "value" : "В этом сканировании нет элементов с ненулевым выделенным размером." } }
       }
     },
     "status.initial" : {


### PR DESCRIPTION
## Summary

Implements **R1.3 — Accurate completed-scan summary** from `docs/ROADMAP.md`.

The scanner now returns a typed `DiskScanResult` with a `CompletedScanSummary`, and the UI no longer reports top-level root children as though they were total scanned items.

## Roadmap alignment

Roadmap stage/slice: **R1 / R1.3**

- Count every successfully identified regular file as scanned, including zero-allocation files.
- Preserve existing allocated-size semantics: only positive filesystem-reported allocated size contributes bytes and the size tree.
- Count successfully enumerated directories below the selected scan root during the existing enumeration; no second full-tree pass.
- Retain allocated bytes, file count, folder count, restricted-location count, and monotonic elapsed duration.
- Keep completed summary separate from transient progress.
- Clear the summary on a new scan, cancellation, and successful Trash mutation because it would no longer exactly describe the current snapshot.
- Keep filesystem boundaries, package/symlink behavior, Trash implementation, and R2 visual design unchanged.

## UI and localization

Completed status is explicit and plural-neutral:

`Scanned · Files · Folders · Restricted · Time`

with synchronized English/Russian catalog strings. A completed scan with no positive allocated-size tree items is distinguished from the initial no-scan state.

## Correctness details

- `foldersScanned` means successfully identified directories encountered **below** the selected scan root; the root itself is not counted.
- `filesScanned` includes successfully identified regular files even when allocated size is zero or unavailable/non-positive.
- `allocatedBytes` remains the sum of positive filesystem-reported allocated sizes that feed the authoritative `FolderUsage` tree.
- elapsed time comes from `ContinuousClock`, so wall-clock changes cannot distort the duration.

## Tests

Adds a disposable temp-directory fixture containing two directories, one allocated regular file, and one zero-allocation regular file. It verifies file/folder counts, restricted count, summary/tree byte agreement, monotonic duration, and final progress/summary consistency.

Closes #29. Tracks #10.