### PR TITLE
R2.1: establish native Zen visual tokens

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -49,7 +49,7 @@ struct ContentView: View {
     @State private var errorMessage = ""
 
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: ZenDesign.Spacing.small) {
             header
             controls
 
@@ -87,7 +87,8 @@ struct ContentView: View {
                 }
             }
         }
-        .padding()
+        .padding(ZenDesign.Spacing.large)
+        .background(ZenDesign.Colors.primaryBackground)
         .frame(minWidth: 800, minHeight: 600)
         .onReceive(viewModel.$items) { items in
             treePresentation.prepare(items, by: sortOption)
@@ -146,14 +147,13 @@ struct ContentView: View {
     }
 
     private var header: some View {
-        VStack(spacing: 8) {
-            HStack(spacing: 12) {
+        VStack(spacing: ZenDesign.Spacing.small) {
+            HStack(spacing: ZenDesign.Spacing.medium) {
                 Text(String(localized: "header.title", defaultValue: "Disk Usage"))
-                    .font(.title)
-                    .bold()
+                    .font(ZenDesign.Typography.windowTitle)
                 Text(viewModel.targetDescription)
-                    .font(.headline)
-                    .foregroundStyle(.secondary)
+                    .font(ZenDesign.Typography.section)
+                    .foregroundStyle(ZenDesign.Colors.secondaryText)
                     .lineLimit(1)
                 Spacer()
 
@@ -174,14 +174,14 @@ struct ContentView: View {
     }
 
     private var controls: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: ZenDesign.Spacing.small) {
             if !viewModel.isScanning {
                 Text(viewModel.status)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .font(ZenDesign.Typography.detail)
+                    .foregroundStyle(ZenDesign.Colors.secondaryText)
             }
 
-            HStack(spacing: 12) {
+            HStack(spacing: ZenDesign.Spacing.medium) {
                 if settings.viewMode == .tree {
                     Picker("", selection: $sortOption) {
                         ForEach(SortOption.allCases) { option in
@@ -238,10 +238,10 @@ struct ContentView: View {
     }
 
     private var emptyState: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: ZenDesign.Spacing.large) {
             Image(systemName: "folder.badge.questionmark")
                 .font(.system(size: 48))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ZenDesign.Colors.mutedText)
             Text(
                 viewModel.completedSummary == nil
                     ? String(localized: "empty.message", defaultValue: "No data. Start a scan.")
@@ -251,15 +251,15 @@ struct ContentView: View {
                     )
             )
             .font(.title3)
-            .foregroundStyle(.secondary)
+            .foregroundStyle(ZenDesign.Colors.secondaryText)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var restrictedBanner: some View {
-        HStack {
+        HStack(spacing: ZenDesign.Spacing.small) {
             Image(systemName: "lock.fill")
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ZenDesign.Colors.mutedText)
             Text(
                 String(
                     format: String(
@@ -269,14 +269,14 @@ struct ContentView: View {
                     viewModel.restricted.count
                 )
             )
-            .font(.caption)
-            .foregroundStyle(.secondary)
+            .font(ZenDesign.Typography.detail)
+            .foregroundStyle(ZenDesign.Colors.secondaryText)
             Spacer()
         }
-        .padding(.horizontal)
-        .padding(.vertical, 8)
-        .background(Color.secondary.opacity(0.1))
-        .cornerRadius(8)
+        .padding(.horizontal, ZenDesign.Spacing.medium)
+        .padding(.vertical, ZenDesign.Spacing.small)
+        .background(ZenDesign.Colors.surface)
+        .clipShape(RoundedRectangle(cornerRadius: ZenDesign.Radius.medium, style: .continuous))
     }
 
     private func chooseFolder() {
@@ -293,11 +293,11 @@ struct ProgressPanel: View {
     let progress: ScanProgress
 
     var body: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: ZenDesign.Spacing.small) {
             ProgressView()
                 .progressViewStyle(.linear)
 
-            HStack(spacing: 16) {
+            HStack(spacing: ZenDesign.Spacing.large) {
                 Label(
                     String(
                         format: String(localized: "progress.files", defaultValue: "%@ files"),
@@ -308,20 +308,20 @@ struct ProgressPanel: View {
                 Label(formatBytes(progress.bytesFound), systemImage: "internaldrive")
                 Spacer()
             }
-            .font(.caption)
-            .foregroundStyle(.secondary)
+            .font(ZenDesign.Typography.detail)
+            .foregroundStyle(ZenDesign.Colors.secondaryText)
             .monospacedDigit()
 
             if !progress.currentFolder.isEmpty {
                 Text(progress.currentFolder)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
+                    .font(ZenDesign.Typography.micro)
+                    .foregroundStyle(ZenDesign.Colors.mutedText)
                     .lineLimit(1)
                     .truncationMode(.middle)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        .padding(.horizontal)
+        .padding(.horizontal, ZenDesign.Spacing.medium)
     }
 }
 
@@ -342,14 +342,14 @@ struct DiskInfoBar: View {
     }
 
     var body: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: ZenDesign.Spacing.medium) {
             Image(systemName: "internaldrive.fill")
                 .font(.system(size: 14))
                 .foregroundStyle(.secondary)
 
             GeometryReader { geometry in
                 ZStack(alignment: .leading) {
-                    Capsule().fill(Color.secondary.opacity(0.2))
+                    Capsule().fill(ZenDesign.Colors.separator.opacity(0.65))
                     Capsule()
                         .fill(barColor)
                         .frame(width: geometry.size.width * usedRatio)
@@ -382,9 +382,9 @@ struct DiskInfoBar: View {
             .font(.caption)
             .monospacedDigit()
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
-        .background(Color.secondary.opacity(0.08))
-        .cornerRadius(6)
+        .padding(.horizontal, ZenDesign.Spacing.medium)
+        .padding(.vertical, ZenDesign.Spacing.small)
+        .background(ZenDesign.Colors.surface)
+        .clipShape(RoundedRectangle(cornerRadius: ZenDesign.Radius.small, style: .continuous))
     }
 }

--- a/DiskUsage.xcodeproj/project.pbxproj
+++ b/DiskUsage.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		09164F04B93E700E14A4D81A /* FolderUsageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B8D41F1654CD51C1A4530EB /* FolderUsageTests.swift */; };
+		A2D74C4E93F144A9B6045C11 /* ZenDesign.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7E63D8A1F204C33A851902D /* ZenDesign.swift */; };
 		0D2D7CB139CF0C3BAD5061D9 /* DiskScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE120206D5311A58B609EA26 /* DiskScannerTests.swift */; };
 		950FB98D2EE0B874003A2FC2 /* DiskUsageApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 950FB98C2EE0B874003A2FC2 /* DiskUsageApp.swift */; };
 		950FB9912EE0B875003A2FC2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 950FB9902EE0B874003A2FC2 /* Assets.xcassets */; };
@@ -39,6 +40,7 @@
 		950FB98C2EE0B874003A2FC2 /* DiskUsageApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskUsageApp.swift; sourceTree = "<group>"; };
 		950FB9902EE0B875003A2FC2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		950FB9972EE0B9C7003A2FC2 /* FolderUsage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderUsage.swift; sourceTree = "<group>"; };
+		B7E63D8A1F204C33A851902D /* ZenDesign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZenDesign.swift; sourceTree = "<group>"; };
 		950FB99B2EE0B9F8003A2FC2 /* DiskScannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskScannerViewModel.swift; sourceTree = "<group>"; };
 		950FB99D2EE0BA15003A2FC2 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		950FB9A02EE0B874003A2FC2 /* DiskUsage.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DiskUsage.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -83,6 +85,7 @@
 				950FB98C2EE0B874003A2FC2 /* DiskUsageApp.swift */,
 				950FB9C22EE6099A003A2FC2 /* FolderContextMenu.swift */,
 				950FB9972EE0B9C7003A2FC2 /* FolderUsage.swift */,
+				B7E63D8A1F204C33A851902D /* ZenDesign.swift */,
 				950FB9BC2EE5A4F2003A2FC2 /* SettingsView.swift */,
 				950FB9BE2EE5B8BC003A2FC2 /* SunburstView.swift */,
 				950FB9C02EE5B8D7003A2FC2 /* TreeView.swift */,
@@ -221,6 +224,7 @@
 				950FB9B92EE45694003A2FC2 /* DiskScanner.swift in Sources */,
 				950FB9BD2EE5A4FB003A2FC2 /* SettingsView.swift in Sources */,
 				950FB9B72EE4564D003A2FC2 /* Utilities.swift in Sources */,
+				A2D74C4E93F144A9B6045C11 /* ZenDesign.swift in Sources */,
 				950FB9C32EE609A1003A2FC2 /* FolderContextMenu.swift in Sources */,
 				950FB98D2EE0B874003A2FC2 /* DiskUsageApp.swift in Sources */,
 				950FB99E2EE0BA5B003A2FC2 /* ContentView.swift in Sources */,

--- a/SunburstView.swift
+++ b/SunburstView.swift
@@ -72,7 +72,7 @@ struct SunburstView: View {
     }
 
     var body: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: ZenDesign.Spacing.medium) {
             breadcrumb
             GeometryReader { geo in
                 let c = CGPoint(x: geo.size.width / 2, y: geo.size.height / 2)
@@ -110,7 +110,7 @@ struct SunburstView: View {
                     }
 
                     Circle()
-                        .fill(Color(NSColor.controlBackgroundColor))
+                        .fill(ZenDesign.Colors.surface)
                         .frame(width: center * 2, height: center * 2)
                         .position(c)
 
@@ -121,7 +121,7 @@ struct SunburstView: View {
                              ? String(localized: "sunburst.scanning", defaultValue: "scanning…")
                              : String(localized: "sunburst.scanned", defaultValue: "scanned"))
                             .font(.system(size: 11))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(ZenDesign.Colors.secondaryText)
                     }
                     .frame(width: center * 1.8)
                     .position(c)
@@ -144,7 +144,7 @@ struct SunburstView: View {
     }
 
     private var breadcrumb: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: ZenDesign.Spacing.small) {
             Button {
                 withAnimation(.easeInOut(duration: 0.3)) { _ = navigation.popLast() }
             } label: {
@@ -153,24 +153,24 @@ struct SunburstView: View {
             .buttonStyle(.bordered)
             .disabled(resolvedPath.isEmpty)
 
-            HStack(spacing: 4) {
+            HStack(spacing: ZenDesign.Spacing.compact) {
                 Button {
                     withAnimation(.easeInOut(duration: 0.3)) { navigation.removeAll() }
                 } label: {
                     Text(verbatim: "/")
                 }
                 .buttonStyle(.plain)
-                .foregroundStyle(resolvedPath.isEmpty ? .primary : .secondary)
+                .foregroundStyle(resolvedPath.isEmpty ? ZenDesign.Colors.primaryText : ZenDesign.Colors.secondaryText)
 
                 ForEach(Array(resolvedPath.enumerated()), id: \.element.path) { index, item in
-                    Image(systemName: "chevron.right").font(.caption2).foregroundStyle(.secondary)
+                    Image(systemName: "chevron.right").font(.caption2).foregroundStyle(ZenDesign.Colors.mutedText)
                     Button(item.name) {
                         withAnimation(.easeInOut(duration: 0.3)) {
                             navigation = Array(navigation.prefix(index + 1))
                         }
                     }
                     .buttonStyle(.plain)
-                    .foregroundStyle(index == resolvedPath.count - 1 ? .primary : .secondary)
+                    .foregroundStyle(index == resolvedPath.count - 1 ? ZenDesign.Colors.primaryText : ZenDesign.Colors.secondaryText)
                     .lineLimit(1)
                 }
             }

--- a/TreeView.swift
+++ b/TreeView.swift
@@ -14,7 +14,7 @@ struct TreeView: View {
         List {
             if items.isEmpty {
                 Text(String(localized: "empty.message", defaultValue: "No data. Start a scan."))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZenDesign.Colors.secondaryText)
                     .padding(.vertical, 20)
             } else {
                 Section(String(localized: "section.items", defaultValue: "Items")) {
@@ -35,8 +35,8 @@ struct TreeView: View {
                     DisclosureGroup(isExpanded: $showRestricted) {
                         ForEach(restricted, id: \.self) {
                             Text($0)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+                                .font(ZenDesign.Typography.detail)
+                                .foregroundStyle(ZenDesign.Colors.secondaryText)
                         }
                         Text(
                             String(
@@ -45,7 +45,7 @@ struct TreeView: View {
                             )
                         )
                         .font(.footnote)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZenDesign.Colors.secondaryText)
                     } label: {
                         Label {
                             Text(
@@ -55,7 +55,7 @@ struct TreeView: View {
                             Image(systemName: "lock.fill")
                         }
                         .font(.subheadline)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(ZenDesign.Colors.secondaryText)
                     }
                 }
             }
@@ -72,16 +72,16 @@ struct ItemRow: View {
     }
 
     var body: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: ZenDesign.Spacing.small) {
             Image(systemName: item.isFile ? "doc" : "folder")
-                .foregroundStyle(item.isFile ? .secondary : Color.accentColor)
+                .foregroundStyle(item.isFile ? ZenDesign.Colors.secondaryText : ZenDesign.Colors.accent)
                 .frame(width: 16)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(item.name).lineLimit(1)
                 Text(item.path)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
+                    .font(ZenDesign.Typography.micro)
+                    .foregroundStyle(ZenDesign.Colors.mutedText)
                     .lineLimit(1)
             }
             .frame(minWidth: 150, alignment: .leading)
@@ -94,8 +94,8 @@ struct ItemRow: View {
             VStack(alignment: .trailing, spacing: 2) {
                 Text(formatBytes(item.size)).monospacedDigit()
                 Text(formatPercent(item.size, of: totalSize))
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
+                    .font(ZenDesign.Typography.micro)
+                    .foregroundStyle(ZenDesign.Colors.mutedText)
                     .monospacedDigit()
             }
             .frame(minWidth: 70, alignment: .trailing)
@@ -119,7 +119,7 @@ struct SizeBar: View {
     var body: some View {
         GeometryReader { geometry in
             ZStack(alignment: .leading) {
-                Capsule().fill(Color.secondary.opacity(0.2))
+                Capsule().fill(ZenDesign.Colors.separator.opacity(0.65))
                 Capsule()
                     .fill(color)
                     .frame(width: max(geometry.size.width * ratio, ratio > 0 ? 2 : 0))

--- a/ZenDesign.swift
+++ b/ZenDesign.swift
@@ -1,0 +1,42 @@
+import AppKit
+import SwiftUI
+
+enum ZenDesign {
+    enum Spacing {
+        static let compact: CGFloat = 4
+        static let small: CGFloat = 8
+        static let medium: CGFloat = 12
+        static let large: CGFloat = 16
+        static let xLarge: CGFloat = 24
+        static let xxLarge: CGFloat = 32
+    }
+
+    enum Radius {
+        static let small: CGFloat = 6
+        static let medium: CGFloat = 8
+        static let large: CGFloat = 12
+    }
+
+    enum Colors {
+        static var primaryBackground: Color { Color(nsColor: NSColor.windowBackgroundColor) }
+        static var surface: Color { Color(nsColor: NSColor.controlBackgroundColor) }
+        static var elevatedSurface: Color { Color(nsColor: NSColor.underPageBackgroundColor) }
+
+        static var primaryText: Color { Color(nsColor: NSColor.labelColor) }
+        static var secondaryText: Color { Color(nsColor: NSColor.secondaryLabelColor) }
+        static var mutedText: Color { Color(nsColor: NSColor.tertiaryLabelColor) }
+
+        static var separator: Color { Color(nsColor: NSColor.separatorColor) }
+        static var accent: Color { Color.accentColor }
+        static var warning: Color { Color(nsColor: NSColor.systemOrange) }
+        static var destructive: Color { Color(nsColor: NSColor.systemRed) }
+    }
+
+    enum Typography {
+        static var windowTitle: Font { .title2.weight(.semibold) }
+        static var section: Font { .headline }
+        static var body: Font { .body }
+        static var detail: Font { .caption }
+        static var micro: Font { .caption2 }
+    }
+}


### PR DESCRIPTION
## Summary

Implements **R2 / R2.1 — Visual tokens** from `docs/ROADMAP.md`.

Adds a compact native `ZenDesign` vocabulary for spacing, corner radii, semantic system-backed colors and typography, then applies it only to representative shell/status/Tree/Sunburst presentation surfaces.

## Scope

- Add `ZenDesign.swift` to the app target.
- Define spacing tokens: 4 / 8 / 12 / 16 / 24 / 32 pt.
- Define modest radius tokens: 6 / 8 / 12 pt.
- Define semantic colors backed by macOS system semantics: window/surface/elevated surfaces, primary/secondary/muted text, separator, accent, warning and destructive.
- Define a small typography vocabulary for window title, section, body, detail and micro text.
- Apply tokens to representative shell/status surfaces, Tree semantic text/accent/separator roles, and Sunburst shared spacing/surface/text roles.
- Keep numeric presentation using the existing `monospacedDigit()` treatment.

## Deliberate non-goals

- no custom RGB Zen palette yet — R2.2 owns palette tuning;
- no main-window restructuring — R2.3 owns composition;
- no full interaction/state redesign — R2.4 owns state polish;
- no Tree row-density change;
- no Sunburst hue/data-palette change;
- no R3 selection/navigation work;
- no scanner, filesystem, Trash, localization, dependency, entitlement or release changes.

## Design rationale

The token layer remains intentionally small and system-backed rather than becoming a generalized theme framework. System semantic colors preserve native Light/Dark behavior and accessibility while giving later R2 slices one shared vocabulary.

## Diff discipline

Exact candidate head: `6fec5efba5cc09b0d3964b2a21273a8d82e5ff09`.

The branch is one commit ahead of `main` and changes exactly five permanent files:

- `ZenDesign.swift`
- `DiskUsage.xcodeproj/project.pbxproj`
- `ContentView.swift`
- `TreeView.swift`
- `SunburstView.swift`

All temporary updater workflows were removed before opening this PR.

## Verification on exact head

- Xcode 26.6 Debug tests: **PASS**
- Xcode 26.6 Release build: **PASS**
- Security / Actions Policy: **PASS**
- Security / Gitleaks: **PASS**
- Dependency Review: **PASS**
- CodeQL Actions: **PASS**
- CodeQL Swift: **in progress** — this PR must not merge until it is green on this exact head.

Closes #34. Tracks #33.