### PR TITLE
R2.2: establish the Zen palette across native surfaces

### DIFF
--- a/Assets.xcassets/ZenBackground.colorset/Contents.json
+++ b/Assets.xcassets/ZenBackground.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.941",
+          "green" : "0.953",
+          "red" : "0.961"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.110",
+          "green" : "0.102",
+          "red" : "0.102"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Assets.xcassets/ZenElevatedSurface.colorset/Contents.json
+++ b/Assets.xcassets/ZenElevatedSurface.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.204",
+          "green" : "0.188",
+          "red" : "0.188"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Assets.xcassets/ZenSurface.colorset/Contents.json
+++ b/Assets.xcassets/ZenSurface.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.976",
+          "green" : "0.984",
+          "red" : "0.988"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.157",
+          "green" : "0.145",
+          "red" : "0.145"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -335,9 +335,9 @@ struct DiskInfoBar: View {
 
     private var barColor: Color {
         switch usedRatio {
-        case ..<0.7: .blue
-        case ..<0.85: .orange
-        default: .red
+        case ..<0.7: ZenDesign.Colors.accent
+        case ..<0.85: ZenDesign.Colors.warning
+        default: ZenDesign.Colors.destructive
         }
     }
 
@@ -345,7 +345,7 @@ struct DiskInfoBar: View {
         HStack(spacing: ZenDesign.Spacing.medium) {
             Image(systemName: "internaldrive.fill")
                 .font(.system(size: 14))
-                .foregroundStyle(.secondary)
+                .foregroundStyle(ZenDesign.Colors.secondaryText)
 
             GeometryReader { geometry in
                 ZStack(alignment: .leading) {
@@ -358,28 +358,28 @@ struct DiskInfoBar: View {
             .frame(height: 8)
             .frame(maxWidth: 200)
 
-            HStack(spacing: 4) {
+            HStack(spacing: ZenDesign.Spacing.compact) {
                 Text(formatBytes(diskInfo.usedSpace))
                     .fontWeight(.medium)
                 Text("/")
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZenDesign.Colors.secondaryText)
                 Text(formatBytes(diskInfo.totalCapacity))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZenDesign.Colors.secondaryText)
                 Text(String(format: "(%.0f%%)", diskInfo.usedPercent))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZenDesign.Colors.secondaryText)
             }
-            .font(.caption)
+            .font(ZenDesign.Typography.detail)
             .monospacedDigit()
 
             Spacer()
 
-            HStack(spacing: 4) {
+            HStack(spacing: ZenDesign.Spacing.compact) {
                 Text(String(localized: "disk.free", defaultValue: "Free:"))
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(ZenDesign.Colors.secondaryText)
                 Text(formatBytes(diskInfo.freeSpace))
                     .fontWeight(.medium)
             }
-            .font(.caption)
+            .font(ZenDesign.Typography.detail)
             .monospacedDigit()
         }
         .padding(.horizontal, ZenDesign.Spacing.medium)

--- a/TreeView.swift
+++ b/TreeView.swift
@@ -107,21 +107,12 @@ struct ItemRow: View {
 struct SizeBar: View {
     let ratio: Double
 
-    private var color: Color {
-        switch ratio {
-        case ..<0.25: .green
-        case ..<0.5: .yellow
-        case ..<0.75: .orange
-        default: .red
-        }
-    }
-
     var body: some View {
         GeometryReader { geometry in
             ZStack(alignment: .leading) {
                 Capsule().fill(ZenDesign.Colors.separator.opacity(0.65))
                 Capsule()
-                    .fill(color)
+                    .fill(ZenDesign.Colors.accent.opacity(0.78))
                     .frame(width: max(geometry.size.width * ratio, ratio > 0 ? 2 : 0))
             }
         }

--- a/ZenDesign.swift
+++ b/ZenDesign.swift
@@ -18,9 +18,9 @@ enum ZenDesign {
     }
 
     enum Colors {
-        static var primaryBackground: Color { Color(nsColor: NSColor.windowBackgroundColor) }
-        static var surface: Color { Color(nsColor: NSColor.controlBackgroundColor) }
-        static var elevatedSurface: Color { Color(nsColor: NSColor.underPageBackgroundColor) }
+        static var primaryBackground: Color { Color("ZenBackground") }
+        static var surface: Color { Color("ZenSurface") }
+        static var elevatedSurface: Color { Color("ZenElevatedSurface") }
 
         static var primaryText: Color { Color(nsColor: NSColor.labelColor) }
         static var secondaryText: Color { Color(nsColor: NSColor.secondaryLabelColor) }


### PR DESCRIPTION
## Summary

Implements **R2 / R2.2 — Zen palette** from `docs/ROADMAP.md` on top of the merged R2.1 token foundation.

Introduces a deliberately small adaptive warm-neutral surface palette for Light/Dark appearances, removes alarm-like rainbow coloring from Tree size bars, and makes volume-usage colors semantic.

## Scope

- Add three native asset-catalog Light/Dark semantic surface colors:
  - `ZenBackground`
  - `ZenSurface`
  - `ZenElevatedSurface`
- Route `ZenDesign.Colors.primaryBackground`, `.surface`, and `.elevatedSurface` through those adaptive assets.
- Keep primary/secondary/muted text, separator, accent, warning and destructive roles backed by macOS system semantics.
- Replace Tree `SizeBar` green/yellow/orange/red magnitude coloring with one restrained accent treatment; bar width remains the magnitude encoding.
- Make disk-volume usage color semantic:
  - normal `<70%` → accent
  - elevated `<85%` → warning
  - critical `>=85%` → destructive
- Keep the numeric used percentage visible so severity never depends on color alone.
- Finish semantic text/spacing treatment inside the existing `DiskInfoBar` without restructuring the shell.

## Deliberate non-goals

- no R2.3 main-window composition/toolbar work;
- no R2.4 state/interaction polish;
- no Sunburst hue/geometry changes — R4 owns the radial visualization redesign;
- no custom text palette that bypasses native accessibility semantics;
- no generalized theme engine or user-selectable themes;
- no scanner, filesystem, Trash, localization, dependency, entitlement, signing or release changes.

## Diff discipline

Exact candidate head: `ee6b26f9f2016e3b92688e766d545f36a5a0a7d3`.

The branch is one commit ahead of `main` and changes exactly six files:

- `Assets.xcassets/ZenBackground.colorset/Contents.json`
- `Assets.xcassets/ZenSurface.colorset/Contents.json`
- `Assets.xcassets/ZenElevatedSurface.colorset/Contents.json`
- `ZenDesign.swift`
- `TreeView.swift`
- `ContentView.swift`

No Xcode project-file change is needed because `Assets.xcassets` is already in the Resources build phase.

## Verification on exact head

- Xcode 26.6 Debug tests: **PASS**
- Xcode 26.6 Release build: **PASS**
- Security / Actions Policy: **PASS**
- Security / Gitleaks: **PASS**
- Dependency Review: **PASS**
- CodeQL Actions: **PASS**
- CodeQL Swift: **in progress** — this PR must not merge until it is green on this exact head.

Closes #35. Tracks #33.