### PR TITLE
R2.3: refine the Zen main-window composition

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -50,11 +50,14 @@ struct ContentView: View {
 
     var body: some View {
         VStack(spacing: ZenDesign.Spacing.small) {
-            header
-            controls
+            workspaceHeader
 
             if viewModel.isScanning {
                 ProgressPanel(progress: viewModel.progress)
+            }
+
+            if settings.viewMode == .tree && !viewModel.items.isEmpty {
+                treeControls
             }
 
             if viewModel.items.isEmpty && !viewModel.isScanning {
@@ -90,6 +93,75 @@ struct ContentView: View {
         .padding(ZenDesign.Spacing.large)
         .background(ZenDesign.Colors.primaryBackground)
         .frame(minWidth: 800, minHeight: 600)
+        .toolbar {
+            ToolbarItem {
+                Picker(
+                    String(localized: "settings.viewMode", defaultValue: "Default View"),
+                    selection: $settings.viewMode
+                ) {
+                    ForEach(ViewMode.allCases) { mode in
+                        Label(mode.title, systemImage: mode.icon)
+                            .labelStyle(.iconOnly)
+                            .tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .frame(width: 88)
+                .help(String(localized: "header.viewMode.help", defaultValue: "Switch view mode"))
+            }
+
+            ToolbarItem(placement: .primaryAction) {
+                if viewModel.isScanning {
+                    Button(role: .cancel) {
+                        viewModel.cancel()
+                    } label: {
+                        Label(
+                            String(localized: "button.cancel", defaultValue: "Cancel"),
+                            systemImage: "xmark.circle"
+                        )
+                    }
+                    .keyboardShortcut(.escape, modifiers: [])
+                } else {
+                    Menu {
+                        Button {
+                            viewModel.scanHome()
+                        } label: {
+                            Label(
+                                String(localized: "button.scanHome", defaultValue: "Scan Home"),
+                                systemImage: "house"
+                            )
+                        }
+
+                        Button {
+                            viewModel.scanRoot()
+                        } label: {
+                            Label(
+                                String(localized: "button.scanRoot", defaultValue: "Scan Disk (/)"),
+                                systemImage: "internaldrive"
+                            )
+                        }
+
+                        Divider()
+
+                        Button {
+                            chooseFolder()
+                        } label: {
+                            Label(
+                                String(localized: "button.chooseFolder", defaultValue: "Choose…"),
+                                systemImage: "folder"
+                            )
+                        }
+                    } label: {
+                        Image(systemName: "magnifyingglass")
+                    }
+                    .help(String(localized: "status.initial", defaultValue: "Choose a folder or start a scan."))
+                    .accessibilityLabel(
+                        Text(String(localized: "status.initial", defaultValue: "Choose a folder or start a scan."))
+                    )
+                }
+            }
+        }
         .onReceive(viewModel.$items) { items in
             treePresentation.prepare(items, by: sortOption)
         }
@@ -146,95 +218,48 @@ struct ContentView: View {
         }
     }
 
-    private var header: some View {
-        VStack(spacing: ZenDesign.Spacing.small) {
-            HStack(spacing: ZenDesign.Spacing.medium) {
-                Text(String(localized: "header.title", defaultValue: "Disk Usage"))
-                    .font(ZenDesign.Typography.windowTitle)
+    private var workspaceHeader: some View {
+        VStack(alignment: .leading, spacing: ZenDesign.Spacing.small) {
+            HStack(spacing: ZenDesign.Spacing.large) {
                 Text(viewModel.targetDescription)
                     .font(ZenDesign.Typography.section)
-                    .foregroundStyle(ZenDesign.Colors.secondaryText)
+                    .foregroundStyle(ZenDesign.Colors.primaryText)
                     .lineLimit(1)
-                Spacer()
+                    .truncationMode(.middle)
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
-                Picker("", selection: $settings.viewMode) {
-                    ForEach(ViewMode.allCases) { mode in
-                        Image(systemName: mode.icon).tag(mode)
-                    }
+                if viewModel.diskInfo.totalCapacity > 0 {
+                    DiskInfoBar(diskInfo: viewModel.diskInfo)
+                        .frame(maxWidth: 520)
                 }
-                .pickerStyle(.segmented)
-                .frame(width: 80)
-                .help(String(localized: "header.viewMode.help", defaultValue: "Switch view mode"))
             }
 
-            if viewModel.diskInfo.totalCapacity > 0 {
-                DiskInfoBar(diskInfo: viewModel.diskInfo)
-            }
-        }
-    }
-
-    private var controls: some View {
-        VStack(alignment: .leading, spacing: ZenDesign.Spacing.small) {
             if !viewModel.isScanning {
                 Text(viewModel.status)
                     .font(ZenDesign.Typography.detail)
                     .foregroundStyle(ZenDesign.Colors.secondaryText)
-            }
-
-            HStack(spacing: ZenDesign.Spacing.medium) {
-                if settings.viewMode == .tree {
-                    Picker("", selection: $sortOption) {
-                        ForEach(SortOption.allCases) { option in
-                            Text(option.title).tag(option)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .frame(width: 200)
-                    .disabled(viewModel.isScanning)
-                }
-
-                Spacer()
-
-                Button {
-                    viewModel.scanHome()
-                } label: {
-                    Label(String(localized: "button.scanHome", defaultValue: "Scan Home"), systemImage: "house")
-                }
-                .disabled(viewModel.isScanning)
-
-                Button {
-                    viewModel.scanRoot()
-                } label: {
-                    Label(
-                        String(localized: "button.scanRoot", defaultValue: "Scan Disk (/)"),
-                        systemImage: "internaldrive"
-                    )
-                }
-                .disabled(viewModel.isScanning)
-
-                Button {
-                    chooseFolder()
-                } label: {
-                    Label(
-                        String(localized: "button.chooseFolder", defaultValue: "Choose…"),
-                        systemImage: "folder"
-                    )
-                }
-                .disabled(viewModel.isScanning)
-
-                if viewModel.isScanning {
-                    Button(role: .cancel) {
-                        viewModel.cancel()
-                    } label: {
-                        Label(
-                            String(localized: "button.cancel", defaultValue: "Cancel"),
-                            systemImage: "xmark.circle"
-                        )
-                    }
-                    .keyboardShortcut(.escape, modifiers: [])
-                }
+                    .lineLimit(2)
             }
         }
+        .padding(.horizontal, ZenDesign.Spacing.medium)
+        .padding(.vertical, ZenDesign.Spacing.small)
+        .background(ZenDesign.Colors.surface)
+        .clipShape(RoundedRectangle(cornerRadius: ZenDesign.Radius.medium, style: .continuous))
+    }
+
+    private var treeControls: some View {
+        HStack {
+            Picker("", selection: $sortOption) {
+                ForEach(SortOption.allCases) { option in
+                    Text(option.title).tag(option)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(width: 200)
+
+            Spacer()
+        }
+        .padding(.horizontal, ZenDesign.Spacing.medium)
     }
 
     private var emptyState: some View {
@@ -356,7 +381,7 @@ struct DiskInfoBar: View {
                 }
             }
             .frame(height: 8)
-            .frame(maxWidth: 200)
+            .frame(maxWidth: 180)
 
             HStack(spacing: ZenDesign.Spacing.compact) {
                 Text(formatBytes(diskInfo.usedSpace))
@@ -371,8 +396,6 @@ struct DiskInfoBar: View {
             .font(ZenDesign.Typography.detail)
             .monospacedDigit()
 
-            Spacer()
-
             HStack(spacing: ZenDesign.Spacing.compact) {
                 Text(String(localized: "disk.free", defaultValue: "Free:"))
                     .foregroundStyle(ZenDesign.Colors.secondaryText)
@@ -382,9 +405,5 @@ struct DiskInfoBar: View {
             .font(ZenDesign.Typography.detail)
             .monospacedDigit()
         }
-        .padding(.horizontal, ZenDesign.Spacing.medium)
-        .padding(.vertical, ZenDesign.Spacing.small)
-        .background(ZenDesign.Colors.surface)
-        .clipShape(RoundedRectangle(cornerRadius: ZenDesign.Radius.small, style: .continuous))
     }
 }


### PR DESCRIPTION
## Summary

Implements **R2 / R2.3 — Main window composition** from `docs/ROADMAP.md` on top of merged R2.1/R2.2.

Refines the app shell into a quieter native macOS workspace: global scan/view controls move into the native toolbar, target/status/volume information becomes one compact supporting strip, and Tree sorting stays adjacent to Tree content instead of competing with global actions.

## Scope

- Replace the stacked custom `header` + `controls` chrome with a native SwiftUI toolbar plus compact supporting content.
- Move the Tree/Sunburst mode switch into the window toolbar using the existing persisted `AppSettings.viewMode` binding.
- Consolidate the three existing scan entry points into one native toolbar menu:
  - Home → existing `viewModel.scanHome()`;
  - root disk → existing `viewModel.scanRoot()`;
  - chosen folder → existing `chooseFolder()` → `viewModel.scan(_:)`.
- While scanning, replace the scan menu with a directly reachable native Cancel button using the existing `viewModel.cancel()` path and Escape shortcut.
- Use an icon-only compact scan menu with the existing localized initial-state string as help/accessibility text, avoiding new localization surface.
- Keep target identity, completed/status text and disk-capacity information visible in one quiet supporting surface.
- Keep scan progress truthful and separate while scanning.
- Show the existing sort segmented control only when Tree mode has actual result content; it remains directly adjacent to Tree content and never appears in Sunburst mode.
- Remove nested card chrome from `DiskInfoBar` so the supporting header reads as one surface rather than stacked dashboard cards.
- Preserve the 800×600 supported minimum window size and truncate long targets in the middle.

## Deliberate non-goals

- no R2.4 lifecycle/state redesign;
- no R3 selection, inspector or navigation model;
- no R4 Sunburst redesign;
- no sidebar architecture or custom toolbar framework;
- no scanner, filesystem, stale-result, cancellation, Finder, copy-path or Trash semantic changes;
- no new localization keys, dependencies, entitlements, signing or release changes.

## Safety / action-path invariants

All global actions still call the same authoritative methods as before. This PR only changes where those controls are presented. Delete confirmation and exact-item Trash flow are untouched.

## Diff discipline

Exact candidate head: `0535a7fa5de5326c18a79b18ab0fb8280436d2e3`.

The branch is one commit ahead of `main` and changes exactly one file:

- `ContentView.swift`

## Verification on exact head

- Xcode 26.6 Debug tests: **PASS**
- Xcode 26.6 Release build: **PASS**
- Security / Actions Policy: **PASS**
- Security / Gitleaks: **PASS**
- Dependency Review: **PASS**
- CodeQL Actions: **PASS**
- CodeQL Swift: **in progress** — do not merge until green on this exact head.

Closes #36. Tracks #33.