### PR TITLE
R2.4: polish application states and interaction feedback

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -5,11 +5,16 @@ import Combine
 @MainActor
 final class TreePresentationState: ObservableObject {
     @Published private(set) var items: [FolderUsage] = []
+    @Published private(set) var isPreparing = false
 
     private var task: Task<Void, Never>?
     private var generation = 0
 
-    func prepare(_ source: [FolderUsage], by option: SortOption) {
+    func prepare(
+        _ source: [FolderUsage],
+        by option: SortOption,
+        preservingCurrent: Bool
+    ) {
         generation &+= 1
         let generation = generation
         task?.cancel()
@@ -17,8 +22,14 @@ final class TreePresentationState: ObservableObject {
         guard !source.isEmpty else {
             task = nil
             items = []
+            isPreparing = false
             return
         }
+
+        if !preservingCurrent {
+            items = []
+        }
+        isPreparing = true
 
         task = Task.detached(priority: .userInitiated) { [source, option] in
             guard let prepared = TreePresentationPreprocessor.sorted(source, by: option) else { return }
@@ -26,6 +37,7 @@ final class TreePresentationState: ObservableObject {
             await MainActor.run { [weak self] in
                 guard let self, self.generation == generation else { return }
                 self.items = prepared
+                self.isPreparing = false
                 self.task = nil
             }
         }
@@ -35,6 +47,7 @@ final class TreePresentationState: ObservableObject {
         generation &+= 1
         task?.cancel()
         task = nil
+        isPreparing = false
     }
 }
 
@@ -52,42 +65,22 @@ struct ContentView: View {
         VStack(spacing: ZenDesign.Spacing.small) {
             workspaceHeader
 
-            if viewModel.isScanning {
+            if viewModel.lifecycle == .scanning {
                 ProgressPanel(progress: viewModel.progress)
             }
 
-            if settings.viewMode == .tree && !viewModel.items.isEmpty {
+            if viewModel.lifecycle == .completed,
+               settings.viewMode == .tree,
+               !viewModel.items.isEmpty {
                 treeControls
             }
 
-            if viewModel.items.isEmpty && !viewModel.isScanning {
-                emptyState
-            } else {
-                switch settings.viewMode {
-                case .tree:
-                    TreeView(
-                        items: treePresentation.items,
-                        totalSize: viewModel.totalSize,
-                        restricted: viewModel.restricted,
-                        onShowInFinder: viewModel.showInFinder,
-                        onCopyPath: viewModel.copyPath,
-                        onDelete: requestDelete
-                    )
-                case .sunburst:
-                    SunburstView(
-                        items: viewModel.items,
-                        totalSize: viewModel.totalSize,
-                        snapshotRevision: viewModel.snapshotRevision,
-                        scanProgress: viewModel.isScanning ? viewModel.progress : nil,
-                        onShowInFinder: viewModel.showInFinder,
-                        onCopyPath: viewModel.copyPath,
-                        onDelete: requestDelete
-                    )
+            content
 
-                    if !viewModel.restricted.isEmpty {
-                        restrictedBanner
-                    }
-                }
+            if viewModel.lifecycle == .completed,
+               !viewModel.restricted.isEmpty,
+               viewModel.items.isEmpty || settings.viewMode == .sunburst {
+                restrictedBanner
             }
         }
         .padding(ZenDesign.Spacing.large)
@@ -163,10 +156,10 @@ struct ContentView: View {
             }
         }
         .onReceive(viewModel.$items) { items in
-            treePresentation.prepare(items, by: sortOption)
+            treePresentation.prepare(items, by: sortOption, preservingCurrent: false)
         }
         .onChange(of: sortOption) { _, option in
-            treePresentation.prepare(viewModel.items, by: option)
+            treePresentation.prepare(viewModel.items, by: option, preservingCurrent: true)
         }
         .onDisappear {
             treePresentation.cancel()
@@ -202,6 +195,53 @@ struct ContentView: View {
         }
     }
 
+    @ViewBuilder
+    private var content: some View {
+        switch viewModel.lifecycle {
+        case .initial:
+            initialState
+        case .scanning:
+            scanningState
+        case .cancelled:
+            cancelledState
+        case .completed:
+            if viewModel.items.isEmpty {
+                completedEmptyState
+            } else {
+                switch settings.viewMode {
+                case .tree:
+                    if treePresentation.items.isEmpty {
+                        preparingState
+                    } else {
+                        TreeView(
+                            items: treePresentation.items,
+                            totalSize: viewModel.totalSize,
+                            restricted: viewModel.restricted,
+                            onShowInFinder: viewModel.showInFinder,
+                            onCopyPath: viewModel.copyPath,
+                            onDelete: requestDelete
+                        )
+                        .overlay(alignment: .topTrailing) {
+                            if treePresentation.isPreparing {
+                                presentationIndicator
+                                    .padding(ZenDesign.Spacing.small)
+                            }
+                        }
+                    }
+                case .sunburst:
+                    SunburstView(
+                        items: viewModel.items,
+                        totalSize: viewModel.totalSize,
+                        snapshotRevision: viewModel.snapshotRevision,
+                        onShowInFinder: viewModel.showInFinder,
+                        onCopyPath: viewModel.copyPath,
+                        onDelete: requestDelete
+                    )
+                }
+            }
+        }
+    }
+
     private func requestDelete(_ item: FolderUsage) {
         if settings.confirmDelete {
             itemToDelete = item
@@ -234,7 +274,7 @@ struct ContentView: View {
                 }
             }
 
-            if !viewModel.isScanning {
+            if viewModel.lifecycle == .completed || viewModel.lifecycle == .cancelled {
                 Text(viewModel.status)
                     .font(ZenDesign.Typography.detail)
                     .foregroundStyle(ZenDesign.Colors.secondaryText)
@@ -262,18 +302,51 @@ struct ContentView: View {
         .padding(.horizontal, ZenDesign.Spacing.medium)
     }
 
-    private var emptyState: some View {
+    private var initialState: some View {
         VStack(spacing: ZenDesign.Spacing.large) {
             Image(systemName: "folder.badge.questionmark")
                 .font(.system(size: 48))
                 .foregroundStyle(ZenDesign.Colors.mutedText)
+            Text(String(localized: "status.initial", defaultValue: "Choose a folder or start a scan."))
+                .font(.title3)
+                .foregroundStyle(ZenDesign.Colors.secondaryText)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var scanningState: some View {
+        VStack(spacing: ZenDesign.Spacing.medium) {
+            ProgressView()
+                .controlSize(.large)
+            Text(String(localized: "status.scanning", defaultValue: "Scanning…"))
+                .font(.title3)
+                .foregroundStyle(ZenDesign.Colors.secondaryText)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var cancelledState: some View {
+        VStack(spacing: ZenDesign.Spacing.large) {
+            Image(systemName: "xmark.circle")
+                .font(.system(size: 48))
+                .foregroundStyle(ZenDesign.Colors.mutedText)
+            Text(String(localized: "status.cancelled", defaultValue: "Cancelled."))
+                .font(.title3)
+                .foregroundStyle(ZenDesign.Colors.secondaryText)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var completedEmptyState: some View {
+        VStack(spacing: ZenDesign.Spacing.large) {
+            Image(systemName: "folder")
+                .font(.system(size: 48))
+                .foregroundStyle(ZenDesign.Colors.mutedText)
             Text(
-                viewModel.completedSummary == nil
-                    ? String(localized: "empty.message", defaultValue: "No data. Start a scan.")
-                    : String(
-                        localized: "status.finished.empty",
-                        defaultValue: "No allocated-size items in this scan."
-                    )
+                String(
+                    localized: "status.finished.empty",
+                    defaultValue: "No allocated-size items in this scan."
+                )
             )
             .font(.title3)
             .foregroundStyle(ZenDesign.Colors.secondaryText)
@@ -281,22 +354,47 @@ struct ContentView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
+    private var preparingState: some View {
+        ProgressView()
+            .controlSize(.large)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var presentationIndicator: some View {
+        ProgressView()
+            .controlSize(.small)
+            .padding(ZenDesign.Spacing.small)
+            .background(ZenDesign.Colors.elevatedSurface)
+            .clipShape(RoundedRectangle(cornerRadius: ZenDesign.Radius.small, style: .continuous))
+    }
+
     private var restrictedBanner: some View {
-        HStack(spacing: ZenDesign.Spacing.small) {
-            Image(systemName: "lock.fill")
-                .foregroundStyle(ZenDesign.Colors.mutedText)
+        VStack(alignment: .leading, spacing: ZenDesign.Spacing.compact) {
+            HStack(spacing: ZenDesign.Spacing.small) {
+                Image(systemName: "lock.fill")
+                    .foregroundStyle(ZenDesign.Colors.mutedText)
+                Text(
+                    String(
+                        format: String(
+                            localized: "restricted.count",
+                            defaultValue: "%d folders without access"
+                        ),
+                        viewModel.restricted.count
+                    )
+                )
+                .font(ZenDesign.Typography.detail)
+                .foregroundStyle(ZenDesign.Colors.secondaryText)
+                Spacer()
+            }
+
             Text(
                 String(
-                    format: String(
-                        localized: "restricted.count",
-                        defaultValue: "%d folders without access"
-                    ),
-                    viewModel.restricted.count
+                    localized: "restricted.hint",
+                    defaultValue: "Grant Full Disk Access in System Settings for complete analysis."
                 )
             )
-            .font(ZenDesign.Typography.detail)
-            .foregroundStyle(ZenDesign.Colors.secondaryText)
-            Spacer()
+            .font(ZenDesign.Typography.micro)
+            .foregroundStyle(ZenDesign.Colors.mutedText)
         }
         .padding(.horizontal, ZenDesign.Spacing.medium)
         .padding(.vertical, ZenDesign.Spacing.small)

--- a/DiskScannerViewModel.swift
+++ b/DiskScannerViewModel.swift
@@ -7,6 +7,13 @@ enum TrashResult {
     case error(String)
 }
 
+enum ScanLifecycle: Equatable {
+    case initial
+    case scanning
+    case completed
+    case cancelled
+}
+
 struct DiskInfo {
     let totalCapacity: Int64
     let usedSpace: Int64
@@ -23,7 +30,7 @@ struct DiskInfo {
 @MainActor
 final class DiskScannerViewModel: ObservableObject {
     @Published private(set) var items: [FolderUsage] = []
-    @Published private(set) var isScanning = false
+    @Published private(set) var lifecycle: ScanLifecycle = .initial
     @Published private(set) var status: String
     @Published private(set) var restricted: [String] = []
     @Published private(set) var targetDescription: String
@@ -32,6 +39,10 @@ final class DiskScannerViewModel: ObservableObject {
     @Published private(set) var diskInfo: DiskInfo = .empty
     @Published private(set) var completedSummary: CompletedScanSummary?
     private(set) var snapshotRevision: UInt64 = 0
+
+    var isScanning: Bool {
+        lifecycle == .scanning
+    }
 
     private let settings: AppSettings
     private var scanTask: Task<Void, Never>?
@@ -78,7 +89,7 @@ final class DiskScannerViewModel: ObservableObject {
         let scanner = DiskScanner()
         let showHiddenFiles = settings.showHiddenFiles
 
-        isScanning = true
+        lifecycle = .scanning
         targetDescription = description ?? url.path
         restricted = []
         totalSize = 0
@@ -123,10 +134,10 @@ final class DiskScannerViewModel: ObservableObject {
     func cancel() {
         scanGeneration &+= 1
         cancelTasks()
-        isScanning = false
         progress = ScanProgress()
         completedSummary = nil
         status = String(localized: "status.cancelled", defaultValue: "Cancelled.")
+        lifecycle = .cancelled
     }
 
     private func finishScan(_ result: DiskScanResult, progress finalProgress: ScanProgress) {
@@ -136,7 +147,6 @@ final class DiskScannerViewModel: ObservableObject {
         progress = finalProgress
         totalSize = result.root.size
         restricted = result.restricted
-        isScanning = false
         completedSummary = result.summary
         snapshotRevision &+= 1
         items = result.root.children
@@ -155,6 +165,7 @@ final class DiskScannerViewModel: ObservableObject {
 
         progress = ScanProgress()
         updateDiskInfo()
+        lifecycle = .completed
     }
 
     private func formatElapsed(_ duration: Duration) -> String {

--- a/DiskUsageTests/DiskScannerTests.swift
+++ b/DiskUsageTests/DiskScannerTests.swift
@@ -78,6 +78,28 @@ final class DiskScannerTests: XCTestCase {
         XCTAssertEqual(scanner.progress.bytesFound, result.summary.allocatedBytes)
     }
 
+    @MainActor
+    func testViewModelLifecycleTransitionsImmediatelyOnStartAndCancel() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let viewModel = DiskScannerViewModel()
+        XCTAssertEqual(viewModel.lifecycle, .initial)
+        XCTAssertFalse(viewModel.isScanning)
+
+        viewModel.scan(root)
+        XCTAssertEqual(viewModel.lifecycle, .scanning)
+        XCTAssertTrue(viewModel.isScanning)
+        XCTAssertTrue(viewModel.items.isEmpty)
+        XCTAssertNil(viewModel.completedSummary)
+
+        viewModel.cancel()
+        XCTAssertEqual(viewModel.lifecycle, .cancelled)
+        XCTAssertFalse(viewModel.isScanning)
+        XCTAssertTrue(viewModel.items.isEmpty)
+        XCTAssertNil(viewModel.completedSummary)
+    }
+
     private func makeTemporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/SunburstView.swift
+++ b/SunburstView.swift
@@ -4,6 +4,7 @@ import Combine
 @MainActor
 final class SunburstPresentationState: ObservableObject {
     @Published private(set) var segments: [SunburstSegment] = []
+    @Published private(set) var isPreparing = false
 
     private var task: Task<Void, Never>?
     private var generation = 0
@@ -16,9 +17,11 @@ final class SunburstPresentationState: ObservableObject {
 
         guard !items.isEmpty, totalSize > 0 else {
             task = nil
+            isPreparing = false
             return
         }
 
+        isPreparing = true
         task = Task.detached(priority: .userInitiated) { [items, totalSize, levels] in
             guard let prepared = SunburstPresentationPreprocessor.segments(
                 for: items,
@@ -29,6 +32,7 @@ final class SunburstPresentationState: ObservableObject {
             await MainActor.run { [weak self] in
                 guard let self, self.generation == generation else { return }
                 self.segments = prepared
+                self.isPreparing = false
                 self.task = nil
             }
         }
@@ -39,6 +43,7 @@ final class SunburstPresentationState: ObservableObject {
         task?.cancel()
         task = nil
         segments = []
+        isPreparing = false
     }
 }
 
@@ -51,6 +56,7 @@ struct SunburstView: View {
     let onCopyPath: (FolderUsage) -> Void
     let onDelete: (FolderUsage) -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @StateObject private var presentation = SunburstPresentationState()
     @State private var navigation: [String] = []
 
@@ -95,7 +101,7 @@ struct SunburstView: View {
                             .overlay(arc.stroke(.white.opacity(0.3), lineWidth: 0.5))
                             .onTapGesture {
                                 if !segment.item.children.isEmpty {
-                                    withAnimation(.easeInOut(duration: 0.3)) {
+                                    updateNavigation {
                                         navigation.append(segment.item.path)
                                     }
                                 }
@@ -129,6 +135,16 @@ struct SunburstView: View {
             }
         }
         .frame(minWidth: 400, minHeight: 400)
+        .overlay(alignment: .topTrailing) {
+            if presentation.isPreparing {
+                ProgressView()
+                    .controlSize(.small)
+                    .padding(ZenDesign.Spacing.small)
+                    .background(ZenDesign.Colors.elevatedSurface)
+                    .clipShape(RoundedRectangle(cornerRadius: ZenDesign.Radius.small, style: .continuous))
+                    .padding(ZenDesign.Spacing.small)
+            }
+        }
         .onAppear {
             preparePresentation()
         }
@@ -146,7 +162,7 @@ struct SunburstView: View {
     private var breadcrumb: some View {
         HStack(spacing: ZenDesign.Spacing.small) {
             Button {
-                withAnimation(.easeInOut(duration: 0.3)) { _ = navigation.popLast() }
+                updateNavigation { _ = navigation.popLast() }
             } label: {
                 Image(systemName: "chevron.left").font(.system(size: 14, weight: .semibold))
             }
@@ -155,7 +171,7 @@ struct SunburstView: View {
 
             HStack(spacing: ZenDesign.Spacing.compact) {
                 Button {
-                    withAnimation(.easeInOut(duration: 0.3)) { navigation.removeAll() }
+                    updateNavigation { navigation.removeAll() }
                 } label: {
                     Text(verbatim: "/")
                 }
@@ -165,7 +181,7 @@ struct SunburstView: View {
                 ForEach(Array(resolvedPath.enumerated()), id: \.element.path) { index, item in
                     Image(systemName: "chevron.right").font(.caption2).foregroundStyle(ZenDesign.Colors.mutedText)
                     Button(item.name) {
-                        withAnimation(.easeInOut(duration: 0.3)) {
+                        updateNavigation {
                             navigation = Array(navigation.prefix(index + 1))
                         }
                     }
@@ -178,6 +194,16 @@ struct SunburstView: View {
             Spacer()
         }
         .padding(.horizontal)
+    }
+
+    private func updateNavigation(_ changes: () -> Void) {
+        if reduceMotion {
+            changes()
+        } else {
+            withAnimation(.easeInOut(duration: 0.3)) {
+                changes()
+            }
+        }
     }
 
     private func preparePresentation() {


### PR DESCRIPTION
## Summary

Implements **R2 / R2.4 — State polish** from `docs/ROADMAP.md` on top of merged R2.3.

The application now has one explicit presentation lifecycle (`initial`, `scanning`, `completed`, `cancelled`) instead of storing an independent `isScanning` boolean, and derived Tree/Sunburst preparation is represented separately from filesystem scan state.

## Scope

- Add typed `ScanLifecycle`; derive `isScanning` from it.
- Make scan start, cancellation and completion transition that lifecycle synchronously and stale-safely.
- Publish terminal `.completed` / `.cancelled` lifecycle only after their associated final/reset state is coherent, preventing transient terminal UI with stale status or snapshot content.
- Keep successful Trash mutation in the completed lifecycle while retaining the existing specific `status.trashed` feedback and authoritative `items` snapshot.
- Switch first-launch, scanning, completed-empty and cancelled presentation from localized-string/summary inference to the typed lifecycle.
- Never show Tree filesystem `No data` merely because async sorting has not published yet.
- Expose a small native derived-preparation progress indication separate from scan progress.
- Preserve currently valid Tree content while a sort-only replacement is prepared; clear presentation on authoritative source replacement so stale hit targets are not interactive.
- Keep Sunburst segment clearing for stale-hit-target safety while showing derived preparation progress.
- Make restricted/incomplete completed results visible even when the allocated-size item list is empty, and include the existing Full Disk Access guidance.
- Respect Reduce Motion for Sunburst navigation transitions.
- Add deterministic temp-directory regression coverage for immediate scan-start/cancel lifecycle transitions.

## Non-goals / invariants

- no R3 selection/navigation implementation;
- no scanner traversal, allocated-size, package/symlink/mount semantics changes;
- no Trash target or OS operation changes;
- no new permissions, entitlement, dependency, release or localization surface;
- no fake scan percentage;
- no ornamental animation/effects.

## Diff discipline

Exact candidate head: `34c9f6098e8b145178bd7bbe9446746a057df222`.

One commit ahead of `main`; exactly four files changed:

- `DiskScannerViewModel.swift`
- `ContentView.swift`
- `SunburstView.swift`
- `DiskUsageTests/DiskScannerTests.swift`

## Verification

Required exact-head gates are intentionally left to GitHub Actions before merge:

- Xcode 26.6 Debug tests
- Xcode 26.6 Release build
- Security / Actions Policy
- Security / Gitleaks
- Dependency Review
- CodeQL Actions
- CodeQL Swift

Do not merge until all required checks are green on the exact candidate head.

Closes #37. Tracks #33.