### PR TITLE
R3.1: add unified selection model

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -51,10 +51,44 @@ final class TreePresentationState: ObservableObject {
     }
 }
 
+@MainActor
+final class ItemSelectionState: ObservableObject {
+    @Published var selectedPath: String?
+
+    func select(_ item: FolderUsage) {
+        selectedPath = item.path
+    }
+
+    func selectedItem(in items: [FolderUsage]) -> FolderUsage? {
+        guard let selectedPath else { return nil }
+        return find(path: selectedPath, in: items)
+    }
+
+    func reconcile(with items: [FolderUsage]) {
+        guard selectedPath != nil else { return }
+        if selectedItem(in: items) == nil {
+            selectedPath = nil
+        }
+    }
+
+    private func find(path: String, in items: [FolderUsage]) -> FolderUsage? {
+        for item in items {
+            if item.path == path {
+                return item
+            }
+            if let match = find(path: path, in: item.children) {
+                return match
+            }
+        }
+        return nil
+    }
+}
+
 struct ContentView: View {
     @StateObject var viewModel: DiskScannerViewModel
     @EnvironmentObject var settings: AppSettings
     @StateObject private var treePresentation = TreePresentationState()
+    @StateObject private var selection = ItemSelectionState()
     @State private var sortOption: SortOption = .sizeDesc
     @State private var itemToDelete: FolderUsage?
     @State private var showDeleteAlert = false
@@ -156,6 +190,7 @@ struct ContentView: View {
             }
         }
         .onReceive(viewModel.$items) { items in
+            selection.reconcile(with: items)
             treePresentation.prepare(items, by: sortOption, preservingCurrent: false)
         }
         .onChange(of: sortOption) { _, option in
@@ -217,6 +252,7 @@ struct ContentView: View {
                             items: treePresentation.items,
                             totalSize: viewModel.totalSize,
                             restricted: viewModel.restricted,
+                            selectedPath: $selection.selectedPath,
                             onShowInFinder: viewModel.showInFinder,
                             onCopyPath: viewModel.copyPath,
                             onDelete: requestDelete
@@ -233,6 +269,7 @@ struct ContentView: View {
                         items: viewModel.items,
                         totalSize: viewModel.totalSize,
                         snapshotRevision: viewModel.snapshotRevision,
+                        selectedPath: $selection.selectedPath,
                         onShowInFinder: viewModel.showInFinder,
                         onCopyPath: viewModel.copyPath,
                         onDelete: requestDelete
@@ -252,7 +289,10 @@ struct ContentView: View {
     }
 
     private func deleteItem(_ item: FolderUsage) {
-        if case .error(let message) = viewModel.moveToTrash(item) {
+        switch viewModel.moveToTrash(item) {
+        case .success:
+            selection.reconcile(with: viewModel.items)
+        case .error(let message):
             errorMessage = message
             showErrorAlert = true
         }

--- a/DiskUsageTests/DiskScannerTests.swift
+++ b/DiskUsageTests/DiskScannerTests.swift
@@ -100,6 +100,38 @@ final class DiskScannerTests: XCTestCase {
         XCTAssertNil(viewModel.completedSummary)
     }
 
+    @MainActor
+    func testSelectionReconcilePreservesPathAcrossSnapshotReplacement() {
+        let oldChild = FolderUsage(path: "/scope/child", size: 100, isFile: true)
+        let oldParent = FolderUsage(path: "/scope", size: 100, children: [oldChild])
+        let replacementChild = FolderUsage(path: "/scope/child", size: 80, isFile: true)
+        let replacementParent = FolderUsage(path: "/scope", size: 80, children: [replacementChild])
+        let selection = ItemSelectionState()
+
+        selection.select(oldChild)
+        selection.reconcile(with: [replacementParent])
+
+        XCTAssertEqual(selection.selectedPath, replacementChild.path)
+        XCTAssertEqual(selection.selectedItem(in: [replacementParent]), replacementChild)
+    }
+
+    @MainActor
+    func testSelectionReconcileClearsPathMissingFromSnapshot() {
+        let child = FolderUsage(path: "/scope/child", size: 100, isFile: true)
+        let parent = FolderUsage(path: "/scope", size: 100, children: [child])
+        let sibling = FolderUsage(path: "/other", size: 50, isFile: true)
+        let selection = ItemSelectionState()
+
+        selection.select(child)
+        selection.reconcile(with: [parent, sibling])
+        XCTAssertEqual(selection.selectedPath, child.path)
+
+        selection.reconcile(with: [sibling])
+
+        XCTAssertNil(selection.selectedPath)
+        XCTAssertNil(selection.selectedItem(in: [sibling]))
+    }
+
     private func makeTemporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/SunburstView.swift
+++ b/SunburstView.swift
@@ -52,6 +52,7 @@ struct SunburstView: View {
     let totalSize: Int64
     let snapshotRevision: UInt64
     var scanProgress: ScanProgress? = nil
+    @Binding var selectedPath: String?
     let onShowInFinder: (FolderUsage) -> Void
     let onCopyPath: (FolderUsage) -> Void
     let onDelete: (FolderUsage) -> Void
@@ -100,6 +101,7 @@ struct SunburstView: View {
                         arc.fill(color)
                             .overlay(arc.stroke(.white.opacity(0.3), lineWidth: 0.5))
                             .onTapGesture {
+                                selectedPath = segment.item.path
                                 if !segment.item.children.isEmpty {
                                     updateNavigation {
                                         navigation.append(segment.item.path)

--- a/TreeView.swift
+++ b/TreeView.swift
@@ -4,6 +4,7 @@ struct TreeView: View {
     let items: [FolderUsage]
     let totalSize: Int64
     let restricted: [String]
+    @Binding var selectedPath: String?
     let onShowInFinder: (FolderUsage) -> Void
     let onCopyPath: (FolderUsage) -> Void
     let onDelete: (FolderUsage) -> Void
@@ -11,7 +12,7 @@ struct TreeView: View {
     @State private var showRestricted = false
 
     var body: some View {
-        List {
+        List(selection: $selectedPath) {
             if items.isEmpty {
                 Text(String(localized: "empty.message", defaultValue: "No data. Start a scan."))
                     .foregroundStyle(ZenDesign.Colors.secondaryText)
@@ -20,6 +21,7 @@ struct TreeView: View {
                 Section(String(localized: "section.items", defaultValue: "Items")) {
                     OutlineGroup(items, children: \.childrenOptional) { item in
                         ItemRow(item: item, totalSize: totalSize)
+                            .tag(item.path)
                             .folderContextMenu(
                                 item,
                                 onShowInFinder: onShowInFinder,


### PR DESCRIPTION
## Roadmap stage

R3.1 — Unified selection model

## Changes

- add one UI-layer path-based `ItemSelectionState`
- bind native Tree selection to the shared state
- let Sunburst taps update the same selection before existing drill-down behavior
- reconcile selection on scan snapshot replacement and after successful Trash
- preserve selection when Trash fails
- add focused regression coverage for path-preserving and missing-path reconciliation

Selection remains non-authoritative: no scanner, `FolderUsage`, filesystem identity, size semantics, or Trash operation semantics are changed.

Closes #44